### PR TITLE
fix(docs): resumo ARIA volta a ser lista com bullets

### DIFF
--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -281,11 +281,16 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>aria-hidden="true"</code> — use em avatars puramente decorativos (ex: ao lado de um nome de usuário visível).<br>
-      <code>alt="Nome do Usuario"</code> — use em avatars com imagem que transmitem identidade (ex: links de perfil).<br>
-      <code>aria-label</code> — use em avatars com ícone para descrever o usuário ou contexto.</span><span data-lang="en"><code>aria-hidden="true"</code> — use on purely decorative avatars (e.g., next to a visible username).<br>
-      <code>alt="User Name"</code> — use on image avatars that convey identity (e.g., profile links).<br>
-      <code>aria-label</code> — use on icon avatars to describe the user or context.</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-hidden="true"</code> — use em avatars puramente decorativos (ex: ao lado de um nome de usuário visível).</li>
+        <li><code>alt="Nome do Usuário"</code> — use em avatars com imagem que transmitem identidade (ex: links de perfil).</li>
+        <li><code>aria-label</code> — use em avatars com ícone para descrever o usuário ou contexto.</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-hidden="true"</code> — use on purely decorative avatars (e.g., next to a visible username).</li>
+        <li><code>alt="User Name"</code> — use on image avatars that convey identity (e.g., profile links).</li>
+        <li><code>aria-label</code> — use on icon avatars to describe the user or context.</li>
+      </ul>
     </div>
   </div>
 

--- a/docs/breadcrumb.html
+++ b/docs/breadcrumb.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/breadcrumb.html
+++ b/docs/breadcrumb.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/breadcrumb.html
+++ b/docs/breadcrumb.html
@@ -351,11 +351,16 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>aria-label="Breadcrumb"</code> — no elemento <code>&lt;nav&gt;</code> para identificar o landmark.<br>
-      <code>aria-current="page"</code> — no item da página atual para comunicar a localização a leitores de tela.<br>
-      Separadores devem ser puramente decorativos (gerados via CSS ou <code>aria-hidden="true"</code>).</span><span data-lang="en"><code>aria-label="Breadcrumb"</code> — on the <code>&lt;nav&gt;</code> element to identify the landmark.<br>
-      <code>aria-current="page"</code> — on the current page item to communicate location to screen readers.<br>
-      Separators should be purely decorative (CSS-generated or <code>aria-hidden="true"</code>).</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-label="Breadcrumb"</code> — no elemento <code>&lt;nav&gt;</code> para identificar o landmark.</li>
+        <li><code>aria-current="page"</code> — no item da página atual para comunicar a localização a leitores de tela.</li>
+        <li>Separadores devem ser puramente decorativos (gerados via CSS ou <code>aria-hidden="true"</code>).</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-label="Breadcrumb"</code> — on the <code>&lt;nav&gt;</code> element to identify the landmark.</li>
+        <li><code>aria-current="page"</code> — on the current page item to communicate location to screen readers.</li>
+        <li>Separators should be purely decorative (CSS-generated or <code>aria-hidden="true"</code>).</li>
+      </ul>
     </div>
   </div>
 

--- a/docs/form-field.html
+++ b/docs/form-field.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/form-field.html
+++ b/docs/form-field.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/form-field.html
+++ b/docs/form-field.html
@@ -603,13 +603,18 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>for</code>/<code>id</code> — associa o label ao input.<br>
-      <code>aria-describedby</code> — vincula texto auxiliar e mensagens de erro ao input.<br>
-      <code>aria-required="true"</code> — defina em inputs obrigatorios.<br>
-      <code>aria-invalid="true"</code> — defina em inputs em estado de erro.</span><span data-lang="en"><code>for</code>/<code>id</code> — associates label with input.<br>
-      <code>aria-describedby</code> — links helper text and error messages to the input.<br>
-      <code>aria-required="true"</code> — set on required inputs.<br>
-      <code>aria-invalid="true"</code> — set on inputs in an error state.</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>for</code>/<code>id</code> — associa o label ao input.</li>
+        <li><code>aria-describedby</code> — vincula texto auxiliar e mensagens de erro ao input.</li>
+        <li><code>aria-required="true"</code> — defina em inputs obrigatórios.</li>
+        <li><code>aria-invalid="true"</code> — defina em inputs em estado de erro.</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>for</code>/<code>id</code> — associates label with input.</li>
+        <li><code>aria-describedby</code> — links helper text and error messages to the input.</li>
+        <li><code>aria-required="true"</code> — set on required inputs.</li>
+        <li><code>aria-invalid="true"</code> — set on inputs in an error state.</li>
+      </ul>
     </div>
   </div>
 

--- a/docs/skeleton.html
+++ b/docs/skeleton.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/skeleton.html
+++ b/docs/skeleton.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/skeleton.html
+++ b/docs/skeleton.html
@@ -343,11 +343,16 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>aria-busy="true"</code> — defina no container que contem os placeholders de skeleton durante o carregamento. Remova quando o conteúdo real aparecer.<br>
-      <code>aria-hidden="true"</code> — defina em formas skeleton individuais (são placeholders visuais, não conteúdo significativo).<br>
-      <code>prefers-reduced-motion</code> — o CSS do skeleton respeita esta media query pausando a animação de pulso.</span><span data-lang="en"><code>aria-busy="true"</code> — set on the container that holds skeleton placeholders while loading. Remove it once real content appears.<br>
-      <code>aria-hidden="true"</code> — set on individual skeleton shapes (they are visual placeholders, not meaningful content).<br>
-      <code>prefers-reduced-motion</code> — the skeleton CSS respects this media query by pausing the pulse animation.</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-busy="true"</code> — defina no container que contém os placeholders de skeleton durante o carregamento. Remova quando o conteúdo real aparecer.</li>
+        <li><code>aria-hidden="true"</code> — defina em formas skeleton individuais (são placeholders visuais, não conteúdo significativo).</li>
+        <li><code>prefers-reduced-motion</code> — o CSS do skeleton respeita esta media query pausando a animação de pulso.</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>aria-busy="true"</code> — set on the container that holds skeleton placeholders while loading. Remove it once real content appears.</li>
+        <li><code>aria-hidden="true"</code> — set on individual skeleton shapes (they are visual placeholders, not meaningful content).</li>
+        <li><code>prefers-reduced-motion</code> — the skeleton CSS respects this media query by pausing the pulse animation.</li>
+      </ul>
     </div>
   </div>
 

--- a/docs/spinner.html
+++ b/docs/spinner.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/spinner.html
+++ b/docs/spinner.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/spinner.html
+++ b/docs/spinner.html
@@ -294,11 +294,16 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>role="status"</code> + <code>aria-label="Loading"</code> — obrigatorio em cada spinner para que leitores de tela anunciem o estado de carregamento.<br>
-      <code>aria-busy="true"</code> — defina no container quando o spinner substitui conteúdo.<br>
-      <code>prefers-reduced-motion</code> — o CSS do spinner respeita esta media query pausando ou reduzindo a animação.</span><span data-lang="en"><code>role="status"</code> + <code>aria-label="Loading"</code> — required on every spinner so screen readers announce the loading state.<br>
-      <code>aria-busy="true"</code> — set on the container when the spinner replaces content.<br>
-      <code>prefers-reduced-motion</code> — the spinner CSS respects this media query by pausing or reducing animation.</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>role="status"</code> + <code>aria-label="Loading"</code> — obrigatório em cada spinner para que leitores de tela anunciem o estado de carregamento.</li>
+        <li><code>aria-busy="true"</code> — defina no container quando o spinner substitui conteúdo.</li>
+        <li><code>prefers-reduced-motion</code> — o CSS do spinner respeita esta media query pausando ou reduzindo a animação.</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>role="status"</code> + <code>aria-label="Loading"</code> — required on every spinner so screen readers announce the loading state.</li>
+        <li><code>aria-busy="true"</code> — set on the container when the spinner replaces content.</li>
+        <li><code>prefers-reduced-motion</code> — the spinner CSS respects this media query by pausing or reducing animation.</li>
+      </ul>
     </div>
   </div>
 

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -18,6 +18,7 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
+    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -18,7 +18,6 @@
     .ds-callout--success { background-color: var(--ds-feedback-success-background); border: var(--ds-border-width-1) solid var(--ds-feedback-success-border); }
     .ds-callout--warning { background-color: var(--ds-feedback-warning-background); border: var(--ds-border-width-1) solid var(--ds-feedback-warning-border); }
     .ds-callout__title { font-weight: var(--ds-font-weight-semibold); margin-bottom: var(--ds-spacing-1); }
-    .ds-callout li::marker { color: var(--ds-content-tertiary); }
     /* Do/Don't */
     .ds-dodont { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ds-spacing-4); margin-bottom: var(--ds-spacing-8); }
     .ds-dodont__item { border-radius: var(--ds-radius-lg); overflow: hidden; }

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -354,19 +354,24 @@
 
     <div class="ds-callout ds-callout--info" style="margin-top:var(--ds-spacing-4)">
       <div class="ds-callout__title"><span data-lang="pt">Resumo dos atributos ARIA</span><span data-lang="en">ARIA attributes summary</span></div>
-      <span data-lang="pt"><code>role="tablist"</code> — no container da lista de tabs.<br>
-      <code>role="tab"</code> — em cada button de tab.<br>
-      <code>role="tabpanel"</code> — em cada painel de conteúdo.<br>
-      <code>aria-selected="true|false"</code> — indica a tab ativa.<br>
-      <code>aria-controls</code> — em cada tab, apontando para o ID do painel correspondente.<br>
-      <code>aria-labelledby</code> — em cada painel, apontando para o ID da tab correspondente.<br>
-      <code>aria-disabled="true"</code> — em tabs desabilitadas.</span><span data-lang="en"><code>role="tablist"</code> — on the tab list container.<br>
-      <code>role="tab"</code> — on each tab button.<br>
-      <code>role="tabpanel"</code> — on each content panel.<br>
-      <code>aria-selected="true|false"</code> — indicates the active tab.<br>
-      <code>aria-controls</code> — on each tab, pointing to the corresponding panel ID.<br>
-      <code>aria-labelledby</code> — on each panel, pointing to the corresponding tab ID.<br>
-      <code>aria-disabled="true"</code> — on disabled tabs.</span>
+      <ul data-lang="pt" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>role="tablist"</code> — no container da lista de tabs.</li>
+        <li><code>role="tab"</code> — em cada button de tab.</li>
+        <li><code>role="tabpanel"</code> — em cada painel de conteúdo.</li>
+        <li><code>aria-selected="true|false"</code> — indica a tab ativa.</li>
+        <li><code>aria-controls</code> — em cada tab, apontando para o ID do painel correspondente.</li>
+        <li><code>aria-labelledby</code> — em cada painel, apontando para o ID da tab correspondente.</li>
+        <li><code>aria-disabled="true"</code> — em tabs desabilitadas.</li>
+      </ul>
+      <ul data-lang="en" style="margin:var(--ds-spacing-2) 0 0;padding-left:var(--ds-spacing-6);">
+        <li><code>role="tablist"</code> — on the tab list container.</li>
+        <li><code>role="tab"</code> — on each tab button.</li>
+        <li><code>role="tabpanel"</code> — on each content panel.</li>
+        <li><code>aria-selected="true|false"</code> — indicates the active tab.</li>
+        <li><code>aria-controls</code> — on each tab, pointing to the corresponding panel ID.</li>
+        <li><code>aria-labelledby</code> — on each panel, pointing to the corresponding tab ID.</li>
+        <li><code>aria-disabled="true"</code> — on disabled tabs.</li>
+      </ul>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

Em 6 páginas de componente, o callout "Resumo dos atributos ARIA" usava `<br>` entre itens. Convertido para `<ul><li>` mantendo toggle PT/EN via `data-lang` no `<ul>`.

Páginas: avatar, breadcrumb, form-field, skeleton, spinner, tabs.

Ajustes incidentais de acento PT-BR (contém, obrigatório).

## Test plan

- [ ] Abrir `docs/skeleton.html` → seção Accessibility → callout com bullets.
- [ ] Alternar PT↔EN: lista substitui conteúdo sem quebrar formatação.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)