### PR TITLE
chore(adr-006): fechar ADR-006 + alinhar semantic control com foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.3]
+
+### Alterado
+- ADR-006 marcada como Aceita — Implementada em 0.5.0. Implementação já havia acontecido via ADR-011; fechamento formal em 0.5.3.
+- `semantic.size.control.*` e `semantic.typography.control.line-height.*` em `tokens/semantic/light.json` e `dark.json` passam a referenciar tokens `foundation.spacing.*` em vez de valores absolutos. Integridade da cadeia de tokens preservada (foundation → semantic).
+
+### Adicionado
+- `component.input.padding-y.{sm,md,lg}` e `component.select.padding-y.{sm,md,lg}` em `tokens/component/input.json` e `select.json`, referenciando `semantic.space.control.padding-y.*`. Gera `--ds-input-padding-y-*` e `--ds-select-padding-y-*` no CSS gerado.
+
+### Corrigido
+- `docs/control-sizing.html` — nomes das CSS vars na tabela agora batem com o que o build realmente emite: `--ds-control-font-size-*` e `--ds-control-line-height-*` (em vez de `--ds-typography-control-*`). O transform `name/strip-layer` remove o segmento `typography` do nome gerado.
+
 ## [0.5.2]
 
 ### Alterado

--- a/css/tokens/generated/component.css
+++ b/css/tokens/generated/component.css
@@ -66,19 +66,6 @@
   --ds-button-height-sm: var(--ds-size-control-sm); /** 32px */
   --ds-button-height-md: var(--ds-size-control-md); /** 40px */
   --ds-button-height-lg: var(--ds-size-control-lg); /** 48px */
-  --ds-button-icon-size-sm: var(--ds-size-control-icon-sm); /** 16px */
-  --ds-button-icon-size-md: var(--ds-size-control-icon-md); /** 20px */
-  --ds-button-icon-size-lg: var(--ds-size-control-icon-lg); /** 24px */
-  --ds-button-min-target-size: var(--ds-size-control-min-target); /** 44px — WCAG 2.5.5 enhanced touch target */
-  --ds-input-height-sm: var(--ds-size-control-sm); /** 32px */
-  --ds-input-height-md: var(--ds-size-control-md); /** 40px */
-  --ds-input-height-lg: var(--ds-size-control-lg); /** 48px */
-  --ds-input-icon-size-sm: var(--ds-size-control-icon-sm); /** 16px */
-  --ds-input-icon-size-md: var(--ds-size-control-icon-md); /** 20px */
-  --ds-input-icon-size-lg: var(--ds-size-control-icon-lg); /** 24px */
-  --ds-select-height-sm: var(--ds-size-control-sm); /** 32px */
-  --ds-select-height-md: var(--ds-size-control-md); /** 40px */
-  --ds-select-height-lg: var(--ds-size-control-lg); /** 48px */
   --ds-button-padding-x-sm: var(--ds-space-control-padding-x-sm); /** 12px horizontal padding */
   --ds-button-padding-x-md: var(--ds-space-control-padding-x-md); /** 16px horizontal padding */
   --ds-button-padding-x-lg: var(--ds-space-control-padding-x-lg); /** 20px horizontal padding */
@@ -91,6 +78,10 @@
   --ds-button-font-size-sm: var(--ds-control-font-size-sm); /** 0.875rem (14px) */
   --ds-button-font-size-md: var(--ds-control-font-size-md); /** 0.875rem (14px) */
   --ds-button-font-size-lg: var(--ds-control-font-size-lg); /** 1rem (16px) */
+  --ds-button-icon-size-sm: var(--ds-size-control-icon-sm); /** 16px */
+  --ds-button-icon-size-md: var(--ds-size-control-icon-md); /** 20px */
+  --ds-button-icon-size-lg: var(--ds-size-control-icon-lg); /** 24px */
+  --ds-button-min-target-size: var(--ds-size-control-min-target); /** 44px — WCAG 2.5.5 enhanced touch target */
   --ds-button-background-toned-default: var(--ds-brand-toned-default); /** Toned variant background. ADR-007. */
   --ds-button-background-toned-hover: var(--ds-brand-toned-hover);
   --ds-button-background-toned-active: var(--ds-brand-toned-active);
@@ -99,22 +90,37 @@
   --ds-button-foreground-toned-disabled: var(--ds-content-disabled);
   --ds-checkbox-border-width: var(--ds-border-width-default);
   --ds-checkbox-gap: var(--ds-space-gap-sm); /** 8px between control and label */
+  --ds-input-height-sm: var(--ds-size-control-sm); /** 32px */
+  --ds-input-height-md: var(--ds-size-control-md); /** 40px */
+  --ds-input-height-lg: var(--ds-size-control-lg); /** 48px */
   --ds-input-padding-x-sm: var(--ds-space-control-padding-x-sm); /** 12px */
   --ds-input-padding-x-md: var(--ds-space-control-padding-x-md); /** 16px */
   --ds-input-padding-x-lg: var(--ds-space-control-padding-x-lg); /** 20px */
+  --ds-input-padding-y-sm: var(--ds-space-control-padding-y-sm); /** 8px */
+  --ds-input-padding-y-md: var(--ds-space-control-padding-y-md); /** 10px */
+  --ds-input-padding-y-lg: var(--ds-space-control-padding-y-lg); /** 12px */
   --ds-input-gap: var(--ds-space-gap-sm); /** 8px gap between icon and field */
   --ds-input-border-radius: var(--ds-radius-component);
   --ds-input-border-width: var(--ds-border-width-default);
   --ds-input-font-size-sm: var(--ds-control-font-size-sm); /** 14px */
   --ds-input-font-size-md: var(--ds-control-font-size-md); /** 14px */
   --ds-input-font-size-lg: var(--ds-control-font-size-lg); /** 16px */
+  --ds-input-icon-size-sm: var(--ds-size-control-icon-sm); /** 16px */
+  --ds-input-icon-size-md: var(--ds-size-control-icon-md); /** 20px */
+  --ds-input-icon-size-lg: var(--ds-size-control-icon-lg); /** 24px */
   --ds-modal-padding: var(--ds-space-inset-lg); /** 16px */
   --ds-modal-header-gap: var(--ds-space-gap-sm); /** 8px between title and close */
   --ds-radio-border-width: var(--ds-border-width-default);
   --ds-radio-gap: var(--ds-space-gap-sm); /** 8px between control and label */
+  --ds-select-height-sm: var(--ds-size-control-sm); /** 32px */
+  --ds-select-height-md: var(--ds-size-control-md); /** 40px */
+  --ds-select-height-lg: var(--ds-size-control-lg); /** 48px */
   --ds-select-padding-x-sm: var(--ds-space-control-padding-x-sm); /** 12px */
   --ds-select-padding-x-md: var(--ds-space-control-padding-x-md); /** 16px */
   --ds-select-padding-x-lg: var(--ds-space-control-padding-x-lg); /** 20px */
+  --ds-select-padding-y-sm: var(--ds-space-control-padding-y-sm); /** 8px */
+  --ds-select-padding-y-md: var(--ds-space-control-padding-y-md); /** 10px */
+  --ds-select-padding-y-lg: var(--ds-space-control-padding-y-lg); /** 12px */
   --ds-select-gap: var(--ds-space-gap-xs); /** 4px */
   --ds-select-border-radius: var(--ds-radius-component);
   --ds-select-border-width: var(--ds-border-width-default);

--- a/css/tokens/generated/theme-dark.css
+++ b/css/tokens/generated/theme-dark.css
@@ -9,16 +9,6 @@
   --ds-feedback-success-content-contrast-disabled: rgba(255, 255, 255, 0.60);
   --ds-feedback-error-disabled: #7B5050;
   --ds-feedback-error-content-contrast-disabled: rgba(255, 255, 255, 0.60);
-  --ds-size-control-sm: 2rem; /** 32px. Height of sm interactive controls (Button, Input Field, Select Field). */
-  --ds-size-control-md: 2.5rem; /** 40px. Height of md interactive controls. */
-  --ds-size-control-lg: 3rem; /** 48px. Height of lg interactive controls. */
-  --ds-size-control-icon-sm: 1rem; /** 16px. Icon size inside sm controls. */
-  --ds-size-control-icon-md: 1.25rem; /** 20px. Icon size inside md controls. */
-  --ds-size-control-icon-lg: 1.5rem; /** 24px. Icon size inside lg controls. */
-  --ds-size-control-min-target: 2.75rem; /** 44px. WCAG 2.5.5 AAA touch target minimum. */
-  --ds-control-line-height-sm: 1rem; /** 16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32. */
-  --ds-control-line-height-md: 1.25rem; /** 20px. Matches icon-md. height = 10+20+10 = 40. */
-  --ds-control-line-height-lg: 1.5rem; /** 24px. Matches icon-lg. height = 12+24+12 = 48. */
   --ds-background-default: var(--ds-color-neutral-950); /** Page background */
   --ds-background-subtle: var(--ds-color-neutral-900); /** Subtle alternate background */
   --ds-background-inverse: var(--ds-color-neutral-50);
@@ -123,9 +113,19 @@
   --ds-space-control-padding-y-md: var(--ds-spacing-2-5); /** 10px. Vertical padding for md controls. */
   --ds-space-control-padding-y-lg: var(--ds-spacing-3); /** 12px. Vertical padding for lg controls. */
   --ds-radius-component: var(--ds-radius-md);
+  --ds-size-control-sm: var(--ds-spacing-8); /** 32px. Height of sm interactive controls (Button, Input Field, Select Field). */
+  --ds-size-control-md: var(--ds-spacing-10); /** 40px. Height of md interactive controls. */
+  --ds-size-control-lg: var(--ds-spacing-12); /** 48px. Height of lg interactive controls. */
+  --ds-size-control-icon-sm: var(--ds-spacing-4); /** 16px. Icon size inside sm controls. */
+  --ds-size-control-icon-md: var(--ds-spacing-5); /** 20px. Icon size inside md controls. */
+  --ds-size-control-icon-lg: var(--ds-spacing-6); /** 24px. Icon size inside lg controls. */
+  --ds-size-control-min-target: var(--ds-spacing-11); /** 44px. WCAG 2.5.5 AAA touch target minimum. */
   --ds-control-font-size-sm: var(--ds-font-size-sm); /** 14px. Font size for sm controls (Button, Input, Select). */
   --ds-control-font-size-md: var(--ds-font-size-sm); /** 14px. Font size for md controls. */
   --ds-control-font-size-lg: var(--ds-font-size-md); /** 16px. Font size for lg controls. */
+  --ds-control-line-height-sm: var(--ds-spacing-4); /** 16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32. */
+  --ds-control-line-height-md: var(--ds-spacing-5); /** 20px. Matches icon-md. height = 10+20+10 = 40. */
+  --ds-control-line-height-lg: var(--ds-spacing-6); /** 24px. Matches icon-lg. height = 12+24+12 = 48. */
   --ds-content-link-hover: var(--ds-brand-hover); /** Links em estado hover. */
   --ds-brand-default: var(--ds-brand-primary); /** Fill brand principal. */
   --ds-accent-default: var(--ds-brand-secondary);

--- a/css/tokens/generated/theme-light.css
+++ b/css/tokens/generated/theme-light.css
@@ -10,16 +10,6 @@
   --ds-feedback-success-content-contrast-disabled: rgba(255, 255, 255, 0.80); /** Conteúdo disabled sobre fill success disabled. */
   --ds-feedback-error-disabled: rgba(194, 112, 112, 0.40); /** Fill error disabled. */
   --ds-feedback-error-content-contrast-disabled: rgba(255, 255, 255, 0.80); /** Conteúdo disabled sobre fill error disabled. */
-  --ds-size-control-sm: 2rem; /** 32px. Height of sm interactive controls (Button, Input Field, Select Field). */
-  --ds-size-control-md: 2.5rem; /** 40px. Height of md interactive controls. */
-  --ds-size-control-lg: 3rem; /** 48px. Height of lg interactive controls. */
-  --ds-size-control-icon-sm: 1rem; /** 16px. Icon size inside sm controls. */
-  --ds-size-control-icon-md: 1.25rem; /** 20px. Icon size inside md controls. */
-  --ds-size-control-icon-lg: 1.5rem; /** 24px. Icon size inside lg controls. */
-  --ds-size-control-min-target: 2.75rem; /** 44px. WCAG 2.5.5 AAA touch target minimum. */
-  --ds-control-line-height-sm: 1rem; /** 16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32. */
-  --ds-control-line-height-md: 1.25rem; /** 20px. Matches icon-md. height = 10+20+10 = 40. */
-  --ds-control-line-height-lg: 1.5rem; /** 24px. Matches icon-lg. height = 12+24+12 = 48. */
   --ds-background-default: var(--ds-color-neutral-50); /** Page background */
   --ds-background-subtle: var(--ds-color-neutral-100); /** Subtle alternate background — one step darker than default to create visual separation. */
   --ds-background-inverse: var(--ds-color-neutral-900);
@@ -124,9 +114,19 @@
   --ds-space-control-padding-y-md: var(--ds-spacing-2-5); /** 10px. Vertical padding for md controls. */
   --ds-space-control-padding-y-lg: var(--ds-spacing-3); /** 12px. Vertical padding for lg controls. */
   --ds-radius-component: var(--ds-radius-md);
+  --ds-size-control-sm: var(--ds-spacing-8); /** 32px. Height of sm interactive controls (Button, Input Field, Select Field). */
+  --ds-size-control-md: var(--ds-spacing-10); /** 40px. Height of md interactive controls. */
+  --ds-size-control-lg: var(--ds-spacing-12); /** 48px. Height of lg interactive controls. */
+  --ds-size-control-icon-sm: var(--ds-spacing-4); /** 16px. Icon size inside sm controls. */
+  --ds-size-control-icon-md: var(--ds-spacing-5); /** 20px. Icon size inside md controls. */
+  --ds-size-control-icon-lg: var(--ds-spacing-6); /** 24px. Icon size inside lg controls. */
+  --ds-size-control-min-target: var(--ds-spacing-11); /** 44px. WCAG 2.5.5 AAA touch target minimum. */
   --ds-control-font-size-sm: var(--ds-font-size-sm); /** 14px. Font size for sm controls (Button, Input, Select). */
   --ds-control-font-size-md: var(--ds-font-size-sm); /** 14px. Font size for md controls. */
   --ds-control-font-size-lg: var(--ds-font-size-md); /** 16px. Font size for lg controls. */
+  --ds-control-line-height-sm: var(--ds-spacing-4); /** 16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32. */
+  --ds-control-line-height-md: var(--ds-spacing-5); /** 20px. Matches icon-md. height = 10+20+10 = 40. */
+  --ds-control-line-height-lg: var(--ds-spacing-6); /** 24px. Matches icon-lg. height = 12+24+12 = 48. */
   --ds-content-link-hover: var(--ds-brand-hover); /** Links em estado hover. */
   --ds-brand-default: var(--ds-brand-primary); /** Fill brand principal (Button Brand, indicadores ativos). */
   --ds-accent-default: var(--ds-brand-secondary); /** Fill de acento (Badge Secondary). */

--- a/docs/adr-index.md
+++ b/docs/adr-index.md
@@ -12,7 +12,7 @@
 | [ADR-003](decisions/ADR-003-fontes-verdade.md) | Figma como autoridade de design, Git como autoridade de tokens/código | Aceita | 2026-04-14 |
 | [ADR-004](decisions/ADR-004-wcag.md) | WCAG 2.2 AA como padrão de acessibilidade | Aceita — Implementada em 0.5.0 | 2026-04-14 |
 | [ADR-005](decisions/ADR-005-brand-foundation-e-estados-explicitos.md) | Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2) | 2026-04-14 |
-| [ADR-006](decisions/ADR-006-semantic-control-tokens.md) | Adopt semantic control tokens for shared dimensions and typography across interactive controls | Proposed | — |
+| [ADR-006](decisions/ADR-006-semantic-control-tokens.md) | Adopt semantic control tokens for shared dimensions and typography across interactive controls | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3) | — |
 | [ADR-007](decisions/ADR-007-toned-color-system.md) | Establish toned color system with colored overlays and semantic toned tokens | Proposed | — |
 | [ADR-008](decisions/ADR-008-recalibracao-paletas-feedback.md) | Recalibração das paletas foundation `green` e `amber` | Aceita — Implementada em 0.5.0 | 2026-04-16 |
 | [ADR-009](decisions/ADR-009-border-control-vs-decorative.md) | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 | 2026-04-16 |

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-04-20T23:50:04.522Z",
+  "generatedAt": "2026-04-20T23:51:34.035Z",
   "totals": {
-    "jsonTokens": 620,
-    "sharedTokens": 356,
+    "jsonTokens": 626,
+    "sharedTokens": 362,
     "lightTokens": 132,
     "darkTokens": 132,
     "errors": 0,

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,20 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.3]</h2>
+<h3>Alterado</h3>
+<ul>
+<li>ADR-006 marcada como Aceita — Implementada em 0.5.0. Implementação já havia acontecido via ADR-011; fechamento formal em 0.5.3.</li>
+<li><code>semantic.size.control.*</code> e <code>semantic.typography.control.line-height.*</code> em <code>tokens/semantic/light.json</code> e <code>dark.json</code> passam a referenciar tokens <code>foundation.spacing.*</code> em vez de valores absolutos. Integridade da cadeia de tokens preservada (foundation → semantic).</li>
+</ul>
+<h3>Adicionado</h3>
+<ul>
+<li><code>component.input.padding-y.{sm,md,lg}</code> e <code>component.select.padding-y.{sm,md,lg}</code> em <code>tokens/component/input.json</code> e <code>select.json</code>, referenciando <code>semantic.space.control.padding-y.*</code>. Gera <code>--ds-input-padding-y-*</code> e <code>--ds-select-padding-y-*</code> no CSS gerado.</li>
+</ul>
+<h3>Corrigido</h3>
+<ul>
+<li><code>docs/control-sizing.html</code> — nomes das CSS vars na tabela agora batem com o que o build realmente emite: <code>--ds-control-font-size-*</code> e <code>--ds-control-line-height-*</code> (em vez de <code>--ds-typography-control-*</code>). O transform <code>name/strip-layer</code> remove o segmento <code>typography</code> do nome gerado.</li>
+</ul>
 <h2>[0.5.2]</h2>
 <h3>Alterado</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,16 +2,16 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-20. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.2**
+> Versão atual: **0.5.3**
 
 ## Status geral
 
 | Componente | CSS | Tokens JSON | Figma (visual) | Figma (binding) | Stories | Docs site |
 |------------|-----|-------------|-----------------|-----------------|---------|----------|
 | Button | 🟢 | 🟢 (25) | 🟢 | 🟢 | ⬜ | 🟢 |
-| Input Text | 🟢 | 🟢 (15) | 🟢 | 🟢 | ⬜ | 🟢 |
+| Input Text | 🟢 | 🟢 (18) | 🟢 | 🟢 | ⬜ | 🟢 |
 | Textarea | 🟢 | 🟢 (14) | 🟢 | 🟢 | ⬜ | 🟢 |
-| Select | 🟢 | 🟢 (16) | 🟢 | 🟢 | ⬜ | 🟢 |
+| Select | 🟢 | 🟢 (19) | 🟢 | 🟢 | ⬜ | 🟢 |
 | Checkbox | 🟢 | 🟢 (14) | 🟢 | 🟢 | ⬜ | 🟢 |
 | Radio | 🟢 | 🟢 (10) | 🟢 | 🟢 | ⬜ | 🟢 |
 | Toggle | 🟢 | 🟢 (12) | 🟢 | 🟢 | ⬜ | 🟢 |
@@ -42,7 +42,7 @@
 | Foundation | 225 | 🟢 |
 | Semantic (light) | 132 | 🟢 |
 | Semantic (dark) | 132 | 🟢 |
-| Component | 131 | 🟢 |
+| Component | 137 | 🟢 |
 
 ## Pipeline
 
@@ -63,7 +63,7 @@
 | ADR-003 | Figma como autoridade de design, Git como autoridade de tokens/código | Aceita |
 | ADR-004 | WCAG 2.2 AA como padrão de acessibilidade | Aceita — Implementada em 0.5.0 |
 | ADR-005 | Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2) |
-| ADR-006 | Adopt semantic control tokens for shared dimensions and typography across interactive controls | Proposed |
+| ADR-006 | Adopt semantic control tokens for shared dimensions and typography across interactive controls | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3) |
 | ADR-007 | Establish toned color system with colored overlays and semantic toned tokens | Proposed |
 | ADR-008 | Recalibração das paletas foundation `green` e `amber` | Aceita — Implementada em 0.5.0 |
 | ADR-009 | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 |

--- a/docs/control-sizing.html
+++ b/docs/control-sizing.html
@@ -80,8 +80,8 @@
         <tr><td><strong><span data-lang="pt">Altura</span><span data-lang="en">Height</span></strong></td><td>32px</td><td>40px</td><td>48px</td><td><code>--ds-size-control-{sm/md/lg}</code></td></tr>
         <tr><td>Padding-x</td><td>12px</td><td>16px</td><td>20px</td><td><code>--ds-space-control-padding-x-{sm/md/lg}</code></td></tr>
         <tr><td>Padding-y</td><td>8px</td><td>10px</td><td>12px</td><td><code>--ds-space-control-padding-y-{sm/md/lg}</code></td></tr>
-        <tr><td>Font-size</td><td>14px</td><td>14px</td><td>16px</td><td><code>--ds-typography-control-font-size-{sm/md/lg}</code></td></tr>
-        <tr><td>Line-height</td><td>16px</td><td>20px</td><td>24px</td><td><code>--ds-typography-control-line-height-{sm/md/lg}</code></td></tr>
+        <tr><td>Font-size</td><td>14px</td><td>14px</td><td>16px</td><td><code>--ds-control-font-size-{sm/md/lg}</code></td></tr>
+        <tr><td>Line-height</td><td>16px</td><td>20px</td><td>24px</td><td><code>--ds-control-line-height-{sm/md/lg}</code></td></tr>
         <tr><td><span data-lang="pt">Tamanho do ícone</span><span data-lang="en">Icon size</span></td><td>16px</td><td>20px</td><td>24px</td><td><code>--ds-size-control-icon-{sm/md/lg}</code></td></tr>
         <tr><td><span data-lang="pt">Alvo mínimo</span><span data-lang="en">Min target</span></td><td colspan="3">44px (WCAG 2.5.5 AAA)</td><td><code>--ds-size-control-min-target</code></td></tr>
       </tbody>

--- a/docs/decisions/ADR-006-semantic-control-tokens.md
+++ b/docs/decisions/ADR-006-semantic-control-tokens.md
@@ -1,6 +1,21 @@
 # ADR-006: Adopt semantic control tokens for shared dimensions and typography across interactive controls
 **Date:** 2026-04-15
-**Status:** Proposed
+**Status:** Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3)
+
+## Implementação
+
+A maior parte foi executada durante ADR-011:
+
+- `semantic.size.control.*`, `semantic.size.control.icon.*`, `semantic.size.control.min-target`, `semantic.space.control.padding-x.*`, `semantic.space.control.padding-y.*`, `semantic.typography.control.font-size.*`, `semantic.typography.control.line-height.*` existem em `tokens/semantic/light.json` e `dark.json`.
+- `tokens/component/button.json`, `input.json`, `select.json`, `textarea.json` referenciam os semantic control tokens. O rename `button.padding.*` → `button.padding-x.*` está aplicado.
+- CSS gerado em `css/tokens/generated/theme-*.css` e `component.css` propaga a cadeia corretamente.
+- Documentação do pattern em `docs/control-sizing.html`.
+
+Fechamento formal em 0.5.3:
+
+- `semantic.size.control.{sm,md,lg}`, `semantic.size.control.icon.{sm,md,lg}`, `semantic.size.control.min-target`, `semantic.typography.control.line-height.{sm,md,lg}` trocaram valores absolutos (`2rem` etc.) por referências a `{foundation.spacing.*}`. Mantém a cadeia token viva: se a escala de spacing mudar, estes derivam automaticamente.
+- `tokens/component/input.json` e `select.json` ganharam `padding-y` explícito apontando para `semantic.space.control.padding-y.*`.
+- `docs/control-sizing.html` ajustado: os nomes documentados `--ds-typography-control-font-size-*` e `--ds-typography-control-line-height-*` foram alinhados para `--ds-control-font-size-*` e `--ds-control-line-height-*` — os nomes que o transform `name/strip-layer` de `build-tokens.mjs` realmente emite (ele remove o segmento `typography`).
 
 ## Pré-requisitos
 

--- a/docs/decisions/adr-006-semantic-control-tokens.html
+++ b/docs/decisions/adr-006-semantic-control-tokens.html
@@ -62,7 +62,7 @@
 <main class="ds-main">
   <div class="ds-section">
     <h1 class="ds-section__title">ADR-006 — Adopt semantic control tokens for shared dimensions and typography across interactive controls</h1>
-    <p class="ds-section__subtitle">Status: <strong>Proposed</strong> · Data: —</p>
+    <p class="ds-section__subtitle">Status: <strong>Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3)</strong> · Data: —</p>
   </div>
 
   <div class="ds-md-generated-banner">
@@ -71,7 +71,21 @@
 
   <div class="ds-md-content">
 <p><strong>Date:</strong> 2026-04-15
-<strong>Status:</strong> Proposed</p>
+<strong>Status:</strong> Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3)</p>
+<h2>Implementação</h2>
+<p>A maior parte foi executada durante ADR-011:</p>
+<ul>
+<li><code>semantic.size.control.*</code>, <code>semantic.size.control.icon.*</code>, <code>semantic.size.control.min-target</code>, <code>semantic.space.control.padding-x.*</code>, <code>semantic.space.control.padding-y.*</code>, <code>semantic.typography.control.font-size.*</code>, <code>semantic.typography.control.line-height.*</code> existem em <code>tokens/semantic/light.json</code> e <code>dark.json</code>.</li>
+<li><code>tokens/component/button.json</code>, <code>input.json</code>, <code>select.json</code>, <code>textarea.json</code> referenciam os semantic control tokens. O rename <code>button.padding.*</code> → <code>button.padding-x.*</code> está aplicado.</li>
+<li>CSS gerado em <code>css/tokens/generated/theme-*.css</code> e <code>component.css</code> propaga a cadeia corretamente.</li>
+<li>Documentação do pattern em <code>docs/control-sizing.html</code>.</li>
+</ul>
+<p>Fechamento formal em 0.5.3:</p>
+<ul>
+<li><code>semantic.size.control.{sm,md,lg}</code>, <code>semantic.size.control.icon.{sm,md,lg}</code>, <code>semantic.size.control.min-target</code>, <code>semantic.typography.control.line-height.{sm,md,lg}</code> trocaram valores absolutos (<code>2rem</code> etc.) por referências a <code>{foundation.spacing.*}</code>. Mantém a cadeia token viva: se a escala de spacing mudar, estes derivam automaticamente.</li>
+<li><code>tokens/component/input.json</code> e <code>select.json</code> ganharam <code>padding-y</code> explícito apontando para <code>semantic.space.control.padding-y.*</code>.</li>
+<li><code>docs/control-sizing.html</code> ajustado: os nomes documentados <code>--ds-typography-control-font-size-*</code> e <code>--ds-typography-control-line-height-*</code> foram alinhados para <code>--ds-control-font-size-*</code> e <code>--ds-control-line-height-*</code> — os nomes que o transform <code>name/strip-layer</code> de <code>build-tokens.mjs</code> realmente emite (ele remove o segmento <code>typography</code>).</li>
+</ul>
 <h2>Pré-requisitos</h2>
 <ul>
 <li>ADR-005 implementada (foundation/brand.json existe, convenção <code>-default</code> consolidada).</li>

--- a/docs/decisions/index.html
+++ b/docs/decisions/index.html
@@ -80,7 +80,7 @@
 <tr><td><a href="adr-003-fontes-verdade.html">ADR-003</a></td><td>Figma como autoridade de design, Git como autoridade de tokens/código</td><td>Aceita</td><td>2026-04-14</td></tr>
 <tr><td><a href="adr-004-wcag.html">ADR-004</a></td><td>WCAG 2.2 AA como padrão de acessibilidade</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-14</td></tr>
 <tr><td><a href="adr-005-brand-foundation-e-estados-explicitos.html">ADR-005</a></td><td>Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica</td><td>Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2)</td><td>2026-04-14</td></tr>
-<tr><td><a href="adr-006-semantic-control-tokens.html">ADR-006</a></td><td>Adopt semantic control tokens for shared dimensions and typography across interactive controls</td><td>Proposed</td><td>—</td></tr>
+<tr><td><a href="adr-006-semantic-control-tokens.html">ADR-006</a></td><td>Adopt semantic control tokens for shared dimensions and typography across interactive controls</td><td>Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3)</td><td>—</td></tr>
 <tr><td><a href="adr-007-toned-color-system.html">ADR-007</a></td><td>Establish toned color system with colored overlays and semantic toned tokens</td><td>Proposed</td><td>—</td></tr>
 <tr><td><a href="adr-008-recalibracao-paletas-feedback.html">ADR-008</a></td><td>Recalibração das paletas foundation `green` e `amber`</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-16</td></tr>
 <tr><td><a href="adr-009-border-control-vs-decorative.html">ADR-009</a></td><td>Separação de `border.default` (decorativa) e `border.control` (funcional)</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-16</td></tr>

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-20. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.2**
+> Versão atual: **0.5.3**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.2 |
+| Versão | 0.5.3 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -20,7 +20,7 @@
 |--------|--------|----------|
 | Foundation | **225** | 10 |
 | Semantic | **132 × 2 modos** | light.json + dark.json |
-| Component | **131** | 11 |
+| Component | **137** | 11 |
 
 ## Foundation (225 tokens)
 
@@ -58,17 +58,17 @@ semantic.size.*
 semantic.typography.*
 ```
 
-## Component (131 tokens)
+## Component (137 tokens)
 
 | Arquivo | Tokens |
 |---------|--------|
 | `avatar.json` | 9 |
 | `button.json` | 25 |
 | `checkbox.json` | 14 |
-| `input.json` | 15 |
+| `input.json` | 18 |
 | `modal.json` | 6 |
 | `radio.json` | 10 |
-| `select.json` | 16 |
+| `select.json` | 19 |
 | `skeleton.json` | 4 |
 | `spinner.json` | 6 |
 | `textarea.json` | 14 |
@@ -95,7 +95,7 @@ semantic.typography.*
 - **ADR-003** — Figma como autoridade de design, Git como autoridade de tokens/código (Aceita)
 - **ADR-004** — WCAG 2.2 AA como padrão de acessibilidade (Aceita — Implementada em 0.5.0)
 - **ADR-005** — Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica (Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2))
-- **ADR-006** — Adopt semantic control tokens for shared dimensions and typography across interactive controls (Proposed)
+- **ADR-006** — Adopt semantic control tokens for shared dimensions and typography across interactive controls (Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3))
 - **ADR-007** — Establish toned color system with colored overlays and semantic toned tokens (Proposed)
 - **ADR-008** — Recalibração das paletas foundation `green` e `amber` (Aceita — Implementada em 0.5.0)
 - **ADR-009** — Separação de `border.default` (decorativa) e `border.control` (funcional) (Aceita — Implementada em 0.5.0)

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,8 +63,8 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-20T23:50:04.522Z</div>
-      <div><strong>Tokens JSON:</strong> 620</div>
+      <div><strong>Última verificação:</strong> 2026-04-20T23:51:34.035Z</div>
+      <div><strong>Tokens JSON:</strong> 626</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.2 -->v0.5.2</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.3 -->v0.5.3</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",

--- a/tokens/component/input.json
+++ b/tokens/component/input.json
@@ -12,6 +12,11 @@
         "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.md}", "$description": "16px" },
         "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.lg}", "$description": "20px" }
       },
+      "padding-y": {
+        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.sm}", "$description": "8px" },
+        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.md}", "$description": "10px" },
+        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.lg}", "$description": "12px" }
+      },
       "gap": { "$type": "dimension", "$value": "{semantic.space.gap.sm}", "$description": "8px gap between icon and field" },
       "border-radius": { "$type": "dimension", "$value": "{semantic.radius.component}" },
       "border-width": { "$type": "dimension", "$value": "{semantic.border.width.default}" },

--- a/tokens/component/select.json
+++ b/tokens/component/select.json
@@ -12,6 +12,11 @@
         "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.md}", "$description": "16px" },
         "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.lg}", "$description": "20px" }
       },
+      "padding-y": {
+        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.sm}", "$description": "8px" },
+        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.md}", "$description": "10px" },
+        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.lg}", "$description": "12px" }
+      },
       "gap": { "$type": "dimension", "$value": "{semantic.space.gap.xs}", "$description": "4px" },
       "border-radius": { "$type": "dimension", "$value": "{semantic.radius.component}" },
       "border-width": { "$type": "dimension", "$value": "{semantic.border.width.default}" },

--- a/tokens/semantic/dark.json
+++ b/tokens/semantic/dark.json
@@ -584,39 +584,39 @@
       "control": {
         "sm": {
           "$type": "dimension",
-          "$value": "2rem",
+          "$value": "{foundation.spacing.8}",
           "$description": "32px. Height of sm interactive controls (Button, Input Field, Select Field)."
         },
         "md": {
           "$type": "dimension",
-          "$value": "2.5rem",
+          "$value": "{foundation.spacing.10}",
           "$description": "40px. Height of md interactive controls."
         },
         "lg": {
           "$type": "dimension",
-          "$value": "3rem",
+          "$value": "{foundation.spacing.12}",
           "$description": "48px. Height of lg interactive controls."
         },
         "icon": {
           "sm": {
             "$type": "dimension",
-            "$value": "1rem",
+            "$value": "{foundation.spacing.4}",
             "$description": "16px. Icon size inside sm controls."
           },
           "md": {
             "$type": "dimension",
-            "$value": "1.25rem",
+            "$value": "{foundation.spacing.5}",
             "$description": "20px. Icon size inside md controls."
           },
           "lg": {
             "$type": "dimension",
-            "$value": "1.5rem",
+            "$value": "{foundation.spacing.6}",
             "$description": "24px. Icon size inside lg controls."
           }
         },
         "min-target": {
           "$type": "dimension",
-          "$value": "2.75rem",
+          "$value": "{foundation.spacing.11}",
           "$description": "44px. WCAG 2.5.5 AAA touch target minimum."
         }
       }
@@ -643,17 +643,17 @@
         "line-height": {
           "sm": {
             "$type": "dimension",
-            "$value": "1rem",
+            "$value": "{foundation.spacing.4}",
             "$description": "16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32."
           },
           "md": {
             "$type": "dimension",
-            "$value": "1.25rem",
+            "$value": "{foundation.spacing.5}",
             "$description": "20px. Matches icon-md. height = 10+20+10 = 40."
           },
           "lg": {
             "$type": "dimension",
-            "$value": "1.5rem",
+            "$value": "{foundation.spacing.6}",
             "$description": "24px. Matches icon-lg. height = 12+24+12 = 48."
           }
         }

--- a/tokens/semantic/light.json
+++ b/tokens/semantic/light.json
@@ -610,39 +610,39 @@
       "control": {
         "sm": {
           "$type": "dimension",
-          "$value": "2rem",
+          "$value": "{foundation.spacing.8}",
           "$description": "32px. Height of sm interactive controls (Button, Input Field, Select Field)."
         },
         "md": {
           "$type": "dimension",
-          "$value": "2.5rem",
+          "$value": "{foundation.spacing.10}",
           "$description": "40px. Height of md interactive controls."
         },
         "lg": {
           "$type": "dimension",
-          "$value": "3rem",
+          "$value": "{foundation.spacing.12}",
           "$description": "48px. Height of lg interactive controls."
         },
         "icon": {
           "sm": {
             "$type": "dimension",
-            "$value": "1rem",
+            "$value": "{foundation.spacing.4}",
             "$description": "16px. Icon size inside sm controls."
           },
           "md": {
             "$type": "dimension",
-            "$value": "1.25rem",
+            "$value": "{foundation.spacing.5}",
             "$description": "20px. Icon size inside md controls."
           },
           "lg": {
             "$type": "dimension",
-            "$value": "1.5rem",
+            "$value": "{foundation.spacing.6}",
             "$description": "24px. Icon size inside lg controls."
           }
         },
         "min-target": {
           "$type": "dimension",
-          "$value": "2.75rem",
+          "$value": "{foundation.spacing.11}",
           "$description": "44px. WCAG 2.5.5 AAA touch target minimum."
         }
       }
@@ -669,17 +669,17 @@
         "line-height": {
           "sm": {
             "$type": "dimension",
-            "$value": "1rem",
+            "$value": "{foundation.spacing.4}",
             "$description": "16px. Matches icon-sm. height = padY*2 + lineHeight = 8+16+8 = 32."
           },
           "md": {
             "$type": "dimension",
-            "$value": "1.25rem",
+            "$value": "{foundation.spacing.5}",
             "$description": "20px. Matches icon-md. height = 10+20+10 = 40."
           },
           "lg": {
             "$type": "dimension",
-            "$value": "1.5rem",
+            "$value": "{foundation.spacing.6}",
             "$description": "24px. Matches icon-lg. height = 12+24+12 = 48."
           }
         }


### PR DESCRIPTION
## Summary

ADR-006 tecnicamente implementada via ADR-011. Esse PR fecha formal + corrige dívidas técnicas:

- semantic.size.control.* e typography.control.line-height.* passam de valores absolutos para referências foundation.
- input.json + select.json ganham padding-y explícito.
- docs/control-sizing.html com nomes de CSS vars alinhados ao output real do build.
- Status ADR-006 → Aceita
- 0.5.2 → 0.5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)