### PR TITLE
fix(tokens): remover rgba/hex literais em semantic (dívida ADR-011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.7]
+
+### Adicionado
+- 6 tokens foundation novos em `tokens/foundation/colors.json`, subcategoria `color.disabled`: `brand-light`, `brand-dark`, `success-light`, `success-dark`, `error-light`, `error-dark`. Valores primitive (hex/rgba) que representam o fill disabled de cada role; viviam antes como literais na camada semantic.
+
+### Corrigido
+- `semantic.brand.disabled`, `semantic.feedback.success.disabled`, `semantic.feedback.error.disabled`, `semantic.brand.content.contrast-disabled`, `semantic.feedback.success.content.contrast-disabled`, `semantic.feedback.error.content.contrast-disabled` em `light.json` e `dark.json` — 12 tokens que tinham valores rgba/hex literais agora referenciam tokens foundation (`color.disabled.*` ou `color.overlay.white.80/60` existentes). Viola menos a regra "semantic nunca hardcoded" (ADR-001). Zero mudança visual.
+- Item correspondente removido do backlog.
+
 ## [0.5.6]
 
 ### Alterado

--- a/css/tokens/generated/foundation.css
+++ b/css/tokens/generated/foundation.css
@@ -133,6 +133,12 @@
   --ds-overlay-blue-400-15: rgba(96, 165, 250, 0.15); /** Blue-400 at 15% opacity. Toned default in dark mode. */
   --ds-overlay-blue-400-25: rgba(96, 165, 250, 0.25); /** Blue-400 at 25% opacity. Toned hover in dark mode. */
   --ds-overlay-blue-400-32: rgba(96, 165, 250, 0.32); /** Blue-400 at 32% opacity. Toned active in dark mode. */
+  --ds-color-disabled-brand-light: rgba(125, 158, 232, 0.50); /** Disabled fill for Button Brand in light mode. */
+  --ds-color-disabled-brand-dark: #4F637D; /** Disabled fill for Button Brand in dark mode (pre-blended opaque). */
+  --ds-color-disabled-success-light: rgba(122, 184, 145, 0.50); /** Disabled fill for Button Success in light mode. */
+  --ds-color-disabled-success-dark: #486E55; /** Disabled fill for Button Success in dark mode. */
+  --ds-color-disabled-error-light: rgba(194, 112, 112, 0.40); /** Disabled fill for Button Danger/Error in light mode. */
+  --ds-color-disabled-error-dark: #7B5050; /** Disabled fill for Button Danger/Error in dark mode. */
   --ds-duration-fast: 150ms;
   --ds-duration-normal: 200ms;
   --ds-duration-slow: 300ms;

--- a/css/tokens/generated/theme-dark.css
+++ b/css/tokens/generated/theme-dark.css
@@ -3,12 +3,6 @@
  */
 
 [data-mode="dark"] {
-  --ds-brand-disabled: #4F637D;
-  --ds-brand-content-contrast-disabled: rgba(255, 255, 255, 0.60);
-  --ds-feedback-success-disabled: #486E55;
-  --ds-feedback-success-content-contrast-disabled: rgba(255, 255, 255, 0.60);
-  --ds-feedback-error-disabled: #7B5050;
-  --ds-feedback-error-content-contrast-disabled: rgba(255, 255, 255, 0.60);
   --ds-background-default: var(--ds-color-neutral-950); /** Page background */
   --ds-background-subtle: var(--ds-color-neutral-900); /** Subtle alternate background */
   --ds-background-inverse: var(--ds-color-neutral-50);
@@ -25,11 +19,13 @@
   --ds-brand-hover: var(--ds-color-blue-300);
   --ds-brand-active: var(--ds-color-blue-200);
   --ds-brand-subtle: var(--ds-color-blue-900);
+  --ds-brand-disabled: var(--ds-color-disabled-brand-dark);
   --ds-brand-toned-default: var(--ds-overlay-blue-400-15); /** Translucent primary bg for toned variants. 15% opacity in dark. */
   --ds-brand-toned-hover: var(--ds-overlay-blue-400-25); /** Toned hover in dark. 25% opacity. */
   --ds-brand-toned-active: var(--ds-overlay-blue-400-32); /** Toned active in dark. 32% opacity. */
   --ds-brand-content-default: var(--ds-color-blue-400); /** Cor brand usada como conteúdo sobre fundo neutro/toned em dark mode. */
   --ds-brand-content-contrast: var(--ds-color-neutral-900); /** Conteúdo de alto contraste sobre fill brand sólido em dark mode. Dark text porque brand default é blue-400 (claro). */
+  --ds-brand-content-contrast-disabled: var(--ds-overlay-white-60);
   --ds-accent-hover: var(--ds-color-purple-300);
   --ds-accent-active: var(--ds-color-purple-200);
   --ds-accent-subtle: var(--ds-color-purple-800);
@@ -41,8 +37,10 @@
   --ds-feedback-success-subtle: var(--ds-color-green-900);
   --ds-feedback-success-background: var(--ds-color-green-950);
   --ds-feedback-success-border: var(--ds-color-green-500);
+  --ds-feedback-success-disabled: var(--ds-color-disabled-success-dark);
   --ds-feedback-success-content-default: var(--ds-color-green-400);
   --ds-feedback-success-content-contrast: var(--ds-color-neutral-900); /** Dark text porque success default em dark é green-500 (claro). */
+  --ds-feedback-success-content-contrast-disabled: var(--ds-overlay-white-60);
   --ds-feedback-warning-default: var(--ds-color-amber-400);
   --ds-feedback-warning-hover: var(--ds-color-amber-300);
   --ds-feedback-warning-subtle: var(--ds-color-amber-900);
@@ -56,8 +54,10 @@
   --ds-feedback-error-subtle: var(--ds-color-red-900);
   --ds-feedback-error-background: var(--ds-color-red-950);
   --ds-feedback-error-border: var(--ds-color-red-500);
+  --ds-feedback-error-disabled: var(--ds-color-disabled-error-dark);
   --ds-feedback-error-content-default: var(--ds-color-red-400);
   --ds-feedback-error-content-contrast: var(--ds-color-neutral-900); /** Dark text porque error default em dark é red-500 (medium). */
+  --ds-feedback-error-content-contrast-disabled: var(--ds-overlay-white-60);
   --ds-feedback-info-default: var(--ds-color-sky-400);
   --ds-feedback-info-hover: var(--ds-color-sky-300);
   --ds-feedback-info-subtle: var(--ds-color-sky-900);

--- a/css/tokens/generated/theme-light.css
+++ b/css/tokens/generated/theme-light.css
@@ -4,12 +4,6 @@
 
 :root,
 [data-mode="light"] {
-  --ds-brand-disabled: rgba(125, 158, 232, 0.50); /** Fill brand em estado disabled. */
-  --ds-brand-content-contrast-disabled: rgba(255, 255, 255, 0.80); /** Conteúdo disabled sobre fill brand disabled. */
-  --ds-feedback-success-disabled: rgba(122, 184, 145, 0.50); /** Fill success disabled. */
-  --ds-feedback-success-content-contrast-disabled: rgba(255, 255, 255, 0.80); /** Conteúdo disabled sobre fill success disabled. */
-  --ds-feedback-error-disabled: rgba(194, 112, 112, 0.40); /** Fill error disabled. */
-  --ds-feedback-error-content-contrast-disabled: rgba(255, 255, 255, 0.80); /** Conteúdo disabled sobre fill error disabled. */
   --ds-background-default: var(--ds-color-neutral-50); /** Page background */
   --ds-background-subtle: var(--ds-color-neutral-100); /** Subtle alternate background — one step darker than default to create visual separation. */
   --ds-background-inverse: var(--ds-color-neutral-900);
@@ -26,11 +20,13 @@
   --ds-brand-hover: var(--ds-color-blue-700); /** Fill brand em hover. */
   --ds-brand-active: var(--ds-color-blue-800); /** Fill brand em active/pressed. */
   --ds-brand-subtle: var(--ds-color-blue-100); /** Fill brand de baixa ênfase (seleções, highlights). */
+  --ds-brand-disabled: var(--ds-color-disabled-brand-light); /** Fill brand em estado disabled. */
   --ds-brand-toned-default: var(--ds-overlay-blue-600-12); /** Fill brand translúcido (Button Toned). 12% opacity. */
   --ds-brand-toned-hover: var(--ds-overlay-blue-600-20); /** Toned hover. 20% opacity. */
   --ds-brand-toned-active: var(--ds-overlay-blue-600-28); /** Toned active/pressed. 28% opacity. */
   --ds-brand-content-default: var(--ds-color-blue-700); /** Cor brand usada como conteúdo (texto/ícone brand sobre fundo neutro, label do Toned). */
   --ds-brand-content-contrast: var(--ds-color-neutral-50); /** Conteúdo de alto contraste sobre fill brand sólido (texto do Button Brand). Unifica color/primary/foreground e text/on-brand (ADR-011). */
+  --ds-brand-content-contrast-disabled: var(--ds-overlay-white-80); /** Conteúdo disabled sobre fill brand disabled. */
   --ds-accent-hover: var(--ds-color-purple-700); /** Acento hover. */
   --ds-accent-active: var(--ds-color-purple-800); /** Acento active. */
   --ds-accent-subtle: var(--ds-color-purple-100); /** Acento de baixa ênfase. */
@@ -42,8 +38,10 @@
   --ds-feedback-success-subtle: var(--ds-color-green-100);
   --ds-feedback-success-background: var(--ds-color-green-50);
   --ds-feedback-success-border: var(--ds-color-green-600);
+  --ds-feedback-success-disabled: var(--ds-color-disabled-success-light); /** Fill success disabled. */
   --ds-feedback-success-content-default: var(--ds-color-green-700); /** Cor success como conteúdo (mensagens, ícones sobre fundo claro). */
   --ds-feedback-success-content-contrast: var(--ds-color-neutral-50); /** Conteúdo de alto contraste sobre fill success sólido. */
+  --ds-feedback-success-content-contrast-disabled: var(--ds-overlay-white-80); /** Conteúdo disabled sobre fill success disabled. */
   --ds-feedback-warning-default: var(--ds-color-amber-500);
   --ds-feedback-warning-hover: var(--ds-color-amber-600);
   --ds-feedback-warning-subtle: var(--ds-color-amber-100);
@@ -57,8 +55,10 @@
   --ds-feedback-error-subtle: var(--ds-color-red-100);
   --ds-feedback-error-background: var(--ds-color-red-50);
   --ds-feedback-error-border: var(--ds-color-red-600);
+  --ds-feedback-error-disabled: var(--ds-color-disabled-error-light); /** Fill error disabled. */
   --ds-feedback-error-content-default: var(--ds-color-red-700); /** Cor error como conteúdo (mensagens de erro, ícones de alerta). */
   --ds-feedback-error-content-contrast: var(--ds-color-neutral-50); /** Conteúdo de alto contraste sobre fill error sólido. */
+  --ds-feedback-error-content-contrast-disabled: var(--ds-overlay-white-80); /** Conteúdo disabled sobre fill error disabled. */
   --ds-feedback-info-default: var(--ds-color-sky-600);
   --ds-feedback-info-hover: var(--ds-color-sky-700);
   --ds-feedback-info-subtle: var(--ds-color-sky-100);

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-04-21T11:00:06.305Z",
+  "generatedAt": "2026-04-21T11:01:59.173Z",
   "totals": {
-    "jsonTokens": 626,
-    "sharedTokens": 362,
+    "jsonTokens": 632,
+    "sharedTokens": 368,
     "lightTokens": 132,
     "darkTokens": 132,
     "errors": 0,

--- a/docs/backlog.html
+++ b/docs/backlog.html
@@ -72,13 +72,6 @@
   <div class="ds-md-content">
 <p>Itens fora do escopo imediato mas que devem ser implementados. Organizados por prioridade.</p>
 <h2>Alta prioridade</h2>
-<h3>Revisitar rgba hardcoded em semantic tokens (dívida de ADR-011)</h3>
-<ul>
-<li><code>semantic.brand.disabled</code> tem <code>rgba(125, 158, 232, 0.50)</code> (light) e <code>#4F637D</code> (dark) literais em <code>tokens/semantic/*.json</code>. Viola a regra &quot;semantic nunca hardcoded&quot;.</li>
-<li><code>semantic.brand.content.contrast-disabled</code> tem <code>rgba(255, 255, 255, 0.80)</code> literal.</li>
-<li>Mesma pattern em <code>feedback.*.disabled</code> e <code>feedback.*.content.contrast-disabled</code>.</li>
-</ul>
-<p>Proposta: criar tokens foundation correspondentes em <code>colors.json</code> (overlay branco/preto ou colored com 40–50%) e apontar semantic pra eles.</p>
 <h3>Preencher <code>docs/brand-principles.md</code></h3>
 <p>Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.</p>
 <h2>Média prioridade</h2>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,14 +4,6 @@ Itens fora do escopo imediato mas que devem ser implementados. Organizados por p
 
 ## Alta prioridade
 
-### Revisitar rgba hardcoded em semantic tokens (dívida de ADR-011)
-
-- `semantic.brand.disabled` tem `rgba(125, 158, 232, 0.50)` (light) e `#4F637D` (dark) literais em `tokens/semantic/*.json`. Viola a regra "semantic nunca hardcoded".
-- `semantic.brand.content.contrast-disabled` tem `rgba(255, 255, 255, 0.80)` literal.
-- Mesma pattern em `feedback.*.disabled` e `feedback.*.content.contrast-disabled`.
-
-Proposta: criar tokens foundation correspondentes em `colors.json` (overlay branco/preto ou colored com 40–50%) e apontar semantic pra eles.
-
 ### Preencher `docs/brand-principles.md`
 
 Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,16 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.7]</h2>
+<h3>Adicionado</h3>
+<ul>
+<li>6 tokens foundation novos em <code>tokens/foundation/colors.json</code>, subcategoria <code>color.disabled</code>: <code>brand-light</code>, <code>brand-dark</code>, <code>success-light</code>, <code>success-dark</code>, <code>error-light</code>, <code>error-dark</code>. Valores primitive (hex/rgba) que representam o fill disabled de cada role; viviam antes como literais na camada semantic.</li>
+</ul>
+<h3>Corrigido</h3>
+<ul>
+<li><code>semantic.brand.disabled</code>, <code>semantic.feedback.success.disabled</code>, <code>semantic.feedback.error.disabled</code>, <code>semantic.brand.content.contrast-disabled</code>, <code>semantic.feedback.success.content.contrast-disabled</code>, <code>semantic.feedback.error.content.contrast-disabled</code> em <code>light.json</code> e <code>dark.json</code> — 12 tokens que tinham valores rgba/hex literais agora referenciam tokens foundation (<code>color.disabled.*</code> ou <code>color.overlay.white.80/60</code> existentes). Viola menos a regra &quot;semantic nunca hardcoded&quot; (ADR-001). Zero mudança visual.</li>
+<li>Item correspondente removido do backlog.</li>
+</ul>
 <h2>[0.5.6]</h2>
 <h3>Alterado</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.6**
+> Versão atual: **0.5.7**
 
 ## Status geral
 
@@ -39,7 +39,7 @@
 
 | Coleção | Tokens | Status |
 |---------|--------|--------|
-| Foundation | 225 | 🟢 |
+| Foundation | 231 | 🟢 |
 | Semantic (light) | 132 | 🟢 |
 | Semantic (dark) | 132 | 🟢 |
 | Component | 137 | 🟢 |

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.6**
+> Versão atual: **0.5.7**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.6 |
+| Versão | 0.5.7 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -18,16 +18,16 @@
 
 | Camada | Tokens | Arquivos |
 |--------|--------|----------|
-| Foundation | **225** | 10 |
+| Foundation | **231** | 10 |
 | Semantic | **132 × 2 modos** | light.json + dark.json |
 | Component | **137** | 11 |
 
-## Foundation (225 tokens)
+## Foundation (231 tokens)
 
 | Arquivo | Tokens |
 |---------|--------|
 | `brand.json` | 2 |
-| `colors.json` | 128 |
+| `colors.json` | 134 |
 | `motion.json` | 7 |
 | `opacity.json` | 7 |
 | `radius.json` | 8 |

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,8 +63,8 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T11:00:06.305Z</div>
-      <div><strong>Tokens JSON:</strong> 626</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T11:01:59.173Z</div>
+      <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.6 -->v0.5.6</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.7 -->v0.5.7</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",

--- a/tokens/foundation/colors.json
+++ b/tokens/foundation/colors.json
@@ -548,6 +548,39 @@
             "$description": "Blue-400 at 32% opacity. Toned active in dark mode."
           }
         }
+      },
+      "disabled": {
+        "$description": "Tint colors for disabled button fills. Pre-blended neutral-leaning values; semantic tokens brand.disabled / feedback.*.disabled alias these.",
+        "brand-light": {
+          "$type": "color",
+          "$value": "rgba(125, 158, 232, 0.50)",
+          "$description": "Disabled fill for Button Brand in light mode."
+        },
+        "brand-dark": {
+          "$type": "color",
+          "$value": "#4F637D",
+          "$description": "Disabled fill for Button Brand in dark mode (pre-blended opaque)."
+        },
+        "success-light": {
+          "$type": "color",
+          "$value": "rgba(122, 184, 145, 0.50)",
+          "$description": "Disabled fill for Button Success in light mode."
+        },
+        "success-dark": {
+          "$type": "color",
+          "$value": "#486E55",
+          "$description": "Disabled fill for Button Success in dark mode."
+        },
+        "error-light": {
+          "$type": "color",
+          "$value": "rgba(194, 112, 112, 0.40)",
+          "$description": "Disabled fill for Button Danger/Error in light mode."
+        },
+        "error-dark": {
+          "$type": "color",
+          "$value": "#7B5050",
+          "$description": "Disabled fill for Button Danger/Error in dark mode."
+        }
       }
     }
   }

--- a/tokens/semantic/dark.json
+++ b/tokens/semantic/dark.json
@@ -100,7 +100,7 @@
       },
       "disabled": {
         "$type": "color",
-        "$value": "#4F637D"
+        "$value": "{foundation.color.disabled.brand-dark}"
       },
       "toned": {
         "default": {
@@ -132,7 +132,7 @@
         },
         "contrast-disabled": {
           "$type": "color",
-          "$value": "rgba(255, 255, 255, 0.60)"
+          "$value": "{foundation.color.overlay.white.60}"
         }
       }
     },
@@ -193,7 +193,7 @@
         },
         "disabled": {
           "$type": "color",
-          "$value": "#486E55"
+          "$value": "{foundation.color.disabled.success-dark}"
         },
         "content": {
           "default": {
@@ -207,7 +207,7 @@
           },
           "contrast-disabled": {
             "$type": "color",
-            "$value": "rgba(255, 255, 255, 0.60)"
+            "$value": "{foundation.color.overlay.white.60}"
           }
         }
       },
@@ -270,7 +270,7 @@
         },
         "disabled": {
           "$type": "color",
-          "$value": "#7B5050"
+          "$value": "{foundation.color.disabled.error-dark}"
         },
         "content": {
           "default": {
@@ -284,7 +284,7 @@
           },
           "contrast-disabled": {
             "$type": "color",
-            "$value": "rgba(255, 255, 255, 0.60)"
+            "$value": "{foundation.color.overlay.white.60}"
           }
         }
       },

--- a/tokens/semantic/light.json
+++ b/tokens/semantic/light.json
@@ -105,7 +105,7 @@
       },
       "disabled": {
         "$type": "color",
-        "$value": "rgba(125, 158, 232, 0.50)",
+        "$value": "{foundation.color.disabled.brand-light}",
         "$description": "Fill brand em estado disabled."
       },
       "toned": {
@@ -138,7 +138,7 @@
         },
         "contrast-disabled": {
           "$type": "color",
-          "$value": "rgba(255, 255, 255, 0.80)",
+          "$value": "{foundation.color.overlay.white.80}",
           "$description": "Conteúdo disabled sobre fill brand disabled."
         }
       }
@@ -207,7 +207,7 @@
         },
         "disabled": {
           "$type": "color",
-          "$value": "rgba(122, 184, 145, 0.50)",
+          "$value": "{foundation.color.disabled.success-light}",
           "$description": "Fill success disabled."
         },
         "content": {
@@ -223,7 +223,7 @@
           },
           "contrast-disabled": {
             "$type": "color",
-            "$value": "rgba(255, 255, 255, 0.80)",
+            "$value": "{foundation.color.overlay.white.80}",
             "$description": "Conteúdo disabled sobre fill success disabled."
           }
         }
@@ -290,7 +290,7 @@
         },
         "disabled": {
           "$type": "color",
-          "$value": "rgba(194, 112, 112, 0.40)",
+          "$value": "{foundation.color.disabled.error-light}",
           "$description": "Fill error disabled."
         },
         "content": {
@@ -306,7 +306,7 @@
           },
           "contrast-disabled": {
             "$type": "color",
-            "$value": "rgba(255, 255, 255, 0.80)",
+            "$value": "{foundation.color.overlay.white.80}",
             "$description": "Conteúdo disabled sobre fill error disabled."
           }
         }


### PR DESCRIPTION
## Summary

12 tokens semantic tinham valores rgba/hex literais, violando a regra "semantic nunca hardcoded" (ADR-001).

Solução:
- 6 tokens novos em foundation (`color.disabled.*`) para os fills coloridos.
- Os 3 contrast-disabled passam a referenciar `overlay.white.80/60` existentes.
- Zero mudança visual.

Bump 0.5.6 → 0.5.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)