### PR TITLE
docs(adr-003): Figma como origem canônica de tokens (reescrita)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.8]
+
+### Alterado
+- ADR-003 reescrita. A versão anterior declarava Git como fonte de verdade para tokens; a revisão reposiciona **Figma Variables como a autoridade canônica** dos valores de token. Git (`tokens/**/*.json`) passa a ser "consolidação derivada em DTCG" em vez de source. Fluxo canônico: Figma → sync manual → JSON → CSS → site. Decisão tomada em 21/04/2026 alinhando a prática à intenção do time (designer decide; dev consolida).
+- CLAUDE.md: seção "Como a pipeline funciona" atualizada com o novo fluxo. Regras de ouro adicionadas: não editar `tokens/*.json` à mão, sempre passar pelo Figma. Lista de scripts em "Ferramentas" lista `sync:tokens-from-figma` (a ser implementado no próximo PR).
+- Backlog reestruturado: item "Sincronização automatizada Figma ↔ site" substituído por "Reduzir documentação textual do Figma" (decisão concreta do time). Adicionados itens "Futuro do site de documentação" (Astro/Zeroheight/Supernova), "Resolução de conflitos inteligente" e "Sincronização automática de tokens" (evoluções futuras).
+
 ## [0.5.7]
 
 ### Adicionado

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,33 +89,46 @@ Título curto em português, corpo em markdown. Seções obrigatórias: **Summar
 
 ## Como a pipeline funciona
 
+Direção canônica (ADR-003 revisada em 0.5.8): **Figma Variables são a fonte de verdade de valores de token**. Git/`tokens/**/*.json` é a consolidação derivada.
+
 ```
-tokens/**/*.json         (DTCG — fonte canônica)
+Figma Variables              (autoridade — designer é o autor)
       │
-      │ build-tokens.mjs (Style Dictionary)
+      │ npm run sync:tokens-from-figma  (manual; abre PR com diff)
       ▼
-css/tokens/generated/*.css  (derivado, marcado AUTO-GENERATED)
+tokens/**/*.json             (DTCG — consolidação canônica em Git)
+      │
+      │ build-tokens.mjs     (Style Dictionary — automático no CI)
+      ▼
+css/tokens/generated/*.css   (derivado, marcado AUTO-GENERATED)
       │
       │ @import em design-system.css
       ▼
-css/components/*.css     (consome as variáveis)
+css/components/*.css         (consome as variáveis)
       │
       ▼
-docs/*.html              (documentação e preview)
+docs/*.html                  (documentação e preview)
 ```
 
-No CI (`.github/workflows/deploy.yml`), `npm run build:tokens` roda em cada push pra main e auto-commita os arquivos gerados.
+Regras de ouro:
+
+- **Nunca editar `tokens/*.json` à mão.** Alterações vêm do Figma via `sync:tokens-from-figma`.
+- **Sempre editar Figma Variables primeiro.** Designer decide, depois o sync propaga.
+- Exceção: PRs gerados pelo próprio script de sync editam os JSONs — é esperado, revisar o diff antes de mergar.
+
+No CI (`.github/workflows/deploy.yml`), `npm run build:tokens` roda em cada push pra main e auto-commita os arquivos CSS gerados. O sync Figma→JSON fica em `.github/workflows/sync-tokens-from-figma.yml`, disparado manualmente via `workflow_dispatch`.
 
 ## Ferramentas disponíveis no repo
 
 ```bash
-npm run build:tokens   # Foundation/Semantic/Component → CSS gerado
-npm run sync:docs      # Regenera inventários em docs/*.md
-# (em breve, via plano de consolidação)
-npm run verify:tokens  # Compara Figma Variables com tokens/*.json
-npm run build:api      # Gera docs/api/*.json
-npm run build:llms     # Gera docs/llms.txt e llms-full.txt
-npm run build:all      # roda todos os builds acima em ordem
+npm run sync:tokens-from-figma         # dry-run: lê Figma Variables e mostra diff vs tokens/*.json
+npm run sync:tokens-from-figma:write   # aplica o diff, regenera CSS, pronto pra commitar
+npm run build:tokens                   # Foundation/Semantic/Component → CSS gerado
+npm run sync:docs                      # Regenera inventários em docs/*.md
+npm run verify:tokens                  # Classifica divergências Figma ↔ JSON (NEEDS_SYNC/DRIFT/VALUE)
+npm run build:api                      # Gera docs/api/*.json
+npm run build:llms                     # Gera docs/llms.txt e llms-full.txt
+npm run build:all                      # roda build:tokens → sync:docs → build:api → build:llms → verify:tokens
 ```
 
 ## Quando houver dúvida

--- a/docs/adr-index.md
+++ b/docs/adr-index.md
@@ -9,7 +9,7 @@
 |-----|--------|--------|------|
 | [ADR-001](decisions/ADR-001-migracao-tokens.md) | Migração da arquitetura de tokens para Foundation→Semantic→Component com DTCG + Style Dictionary | Aceita | 2026-04-14 |
 | [ADR-002](decisions/ADR-002-stack-agnostica.md) | Stack agnóstica — HTML + CSS + vanilla JS como base | Aceita | 2026-04-14 |
-| [ADR-003](decisions/ADR-003-fontes-verdade.md) | Figma como autoridade de design, Git como autoridade de tokens/código | Aceita | 2026-04-14 |
+| [ADR-003](decisions/ADR-003-fontes-verdade.md) | Figma como origem canônica de tokens, Git como consolidação | Aceita — Revisada em 0.5.8 | 2026-04-14 (original) · 2026-04-21 (revisada) |
 | [ADR-004](decisions/ADR-004-wcag.md) | WCAG 2.2 AA como padrão de acessibilidade | Aceita — Implementada em 0.5.0 | 2026-04-14 |
 | [ADR-005](decisions/ADR-005-brand-foundation-e-estados-explicitos.md) | Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2) | 2026-04-14 |
 | [ADR-006](decisions/ADR-006-semantic-control-tokens.md) | Tokens semânticos de controle para dimensões e tipografia compartilhadas entre controles interativos | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3) | 2026-04-15 |

--- a/docs/backlog.html
+++ b/docs/backlog.html
@@ -74,22 +74,46 @@
 <h2>Alta prioridade</h2>
 <h3>Preencher <code>docs/brand-principles.md</code></h3>
 <p>Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.</p>
+<h3>Reduzir documentação textual do Figma</h3>
+<p>Decisão tomada em 21/04/2026 junto com a revisão da ADR-003: reduzir as páginas textuais do Figma (Introdução, Theming, Accessibility, Changelog) e concentrar a documentação de desenvolvimento no GitHub. Tarefa manual, Figma:</p>
+<ul>
+<li>Esvaziar conteúdo narrativo das páginas textuais mencionadas.</li>
+<li>Manter uma referência curta em cada (&quot;Ver documentação completa: <a href="https://uxindesign.github.io/design-system-core/">https://uxindesign.github.io/design-system-core/</a>...&quot;).</li>
+<li>Eventualmente consolidar tudo na Capa.</li>
+<li>Component Status pode ficar como está (é informação visual útil no contexto Figma).</li>
+</ul>
 <h2>Média prioridade</h2>
-<h3>Comparação completa Figma ↔ JSON no <code>scripts/tokens-verify.mjs</code></h3>
-<p>Primeira versão do script confirma conectividade e coleta contagens. Próxima iteração: comparação nome-por-nome, valor-por-valor, modo-por-modo, com resolução de alias Figma e normalização de formato. Adiciona valor depois que o FIGMA_PAT está configurado como secret do CI.</p>
-<h3>Sincronização automatizada Figma ↔ site (Fase 7 do plano)</h3>
-<p>Script Node usando MCP remoto que sincroniza textos de documentação entre site e nodes do Figma marcados com convenção <code>&lt;sync:...&gt;</code>. Ver descrição completa em <code>docs/process-figma-sync.html</code> (a ser criado).</p>
+<h3>Comparação avançada Figma ↔ JSON no <code>scripts/tokens-verify.mjs</code></h3>
+<p>A partir de 0.5.8, o script classifica divergências em <code>NEEDS_SYNC</code>, <code>DRIFT_FROM_SOURCE</code> e <code>VALUE_DRIFT</code>. Próxima iteração: resolução completa de aliases Figma e normalização de formato (hex vs rgba). Depois do FIGMA_PAT ficar configurado como secret do CI.</p>
+<h3>Futuro do site de documentação</h3>
+<p>Avaliar opções quando a manutenção manual do site virar gargalo:</p>
+<ul>
+<li><strong>Astro</strong>: permite manter HTML + MDX, adiciona autor-experience sem mudar a filosofia atual.</li>
+<li><strong>Zeroheight</strong>: CMS especializado em design system, integração forte com Figma, custo recorrente.</li>
+<li><strong>Supernova</strong>: similar ao Zeroheight, com sync bidirecional Figma ↔ doc.</li>
+<li><strong>Manter custom</strong>: evoluir o <code>sync-docs.mjs</code> com editor WYSIWYG interno.</li>
+</ul>
+<p>Decisão aguarda: volume de contribuição, necessidade de editores não-técnicos, orçamento. Por ora, o fluxo MD → HTML via <code>marked</code> no <code>sync-docs.mjs</code> atende.</p>
+<h3>Sincronização automática de tokens (webhook ou agendado)</h3>
+<p>A Fase 7 implementou sync manual via <code>workflow_dispatch</code>. Evoluir pra:</p>
+<ul>
+<li>Webhook do Figma disparando o workflow quando Variables são modificadas.</li>
+<li>Ou agendamento diário (cron) pra detectar mudanças e abrir PR.</li>
+</ul>
+<p>Só se o disparo manual virar gargalo.</p>
+<h3>Sincronização de textos Figma ↔ site</h3>
+<p>A Fase 7 original previa. Substituída pela decisão de reduzir doc textual do Figma (item acima). Se no futuro houver demanda real de ter textos idênticos em ambos os lados, reavaliar.</p>
 <h2>Baixa prioridade</h2>
 <h3>Storybook</h3>
-<p>Componente inventory marca como pendente. Hoje o site cumpre o papel de vitrine interativa. Só implementar se houver demanda explícita de time Dev consumidor.</p>
+<p>Componente inventory marca como pendente. Hoje o site cumpre o papel de vitrine interativa. Só implementar se houver demanda explícita de time Dev consumidor. Integração com os tokens DTCG já gerados (formato padrão de import), sem reinventar.</p>
 <h3>MCP próprio do design system</h3>
 <p>Expõe tokens, componentes e guidelines via MCP para agentes. <code>llms.txt</code> + APIs JSON cobrem a maior parte dos casos. Implementar só se aparecer um caso onde MCP próprio faz diferença real.</p>
 <h3>Publicação no npm</h3>
 <p>Pacote nunca foi publicado. Decidir quando (e com qual nome de escopo) fazer o primeiro publish. Antes de publicar, validar que <code>files</code> no <code>package.json</code> cobre o que deve ser distribuído.</p>
 <h3>Revisão das páginas do Figma em estado de teste</h3>
 <p>Você mencionou que páginas vazias (Icons, Grids, Images, Templates) e resíduos nas páginas de componente (SECTION e <code>image 1</code> em Input Text, INSTANCE soltas em Button, <code>Frame 1</code> em Textarea) estão em uso para experimentos. Quando terminar os testes, decidir se preenche ou remove.</p>
-<h3>Contraste dos 65 warnings de <code>tokens-verify</code></h3>
-<p>Tokens em JSON sem CSS custom property equivalente — sobretudo overlays (<code>foundation.color.overlay.*</code>), tipografia e <code>semantic.typography.control.*</code>. Investigar caso a caso se deveriam gerar CSS var ou se a omissão é intencional (tokens intermediários).</p>
+<h3>Resolução de conflitos inteligente no <code>sync-tokens-from-figma</code></h3>
+<p>Hoje o script loga e pede intervenção quando encontra ambiguidade (ex: variável renomeada no Figma vs variável nova; alias quebrado). Evoluir pra sugerir ação com heurística (ex: &quot;detectei que <code>color/primary/toned</code> pode ter virado <code>brand/toned/default</code> com base em similaridade de valor; aplicar?&quot;).</p>
 
   </div>
 </main>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,21 +8,50 @@ Itens fora do escopo imediato mas que devem ser implementados. Organizados por p
 
 Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.
 
+### Reduzir documentação textual do Figma
+
+Decisão tomada em 21/04/2026 junto com a revisão da ADR-003: reduzir as páginas textuais do Figma (Introdução, Theming, Accessibility, Changelog) e concentrar a documentação de desenvolvimento no GitHub. Tarefa manual, Figma:
+
+- Esvaziar conteúdo narrativo das páginas textuais mencionadas.
+- Manter uma referência curta em cada ("Ver documentação completa: https://uxindesign.github.io/design-system-core/...").
+- Eventualmente consolidar tudo na Capa.
+- Component Status pode ficar como está (é informação visual útil no contexto Figma).
+
 ## Média prioridade
 
-### Comparação completa Figma ↔ JSON no `scripts/tokens-verify.mjs`
+### Comparação avançada Figma ↔ JSON no `scripts/tokens-verify.mjs`
 
-Primeira versão do script confirma conectividade e coleta contagens. Próxima iteração: comparação nome-por-nome, valor-por-valor, modo-por-modo, com resolução de alias Figma e normalização de formato. Adiciona valor depois que o FIGMA_PAT está configurado como secret do CI.
+A partir de 0.5.8, o script classifica divergências em `NEEDS_SYNC`, `DRIFT_FROM_SOURCE` e `VALUE_DRIFT`. Próxima iteração: resolução completa de aliases Figma e normalização de formato (hex vs rgba). Depois do FIGMA_PAT ficar configurado como secret do CI.
 
-### Sincronização automatizada Figma ↔ site (Fase 7 do plano)
+### Futuro do site de documentação
 
-Script Node usando MCP remoto que sincroniza textos de documentação entre site e nodes do Figma marcados com convenção `<sync:...>`. Ver descrição completa em `docs/process-figma-sync.html` (a ser criado).
+Avaliar opções quando a manutenção manual do site virar gargalo:
+
+- **Astro**: permite manter HTML + MDX, adiciona autor-experience sem mudar a filosofia atual.
+- **Zeroheight**: CMS especializado em design system, integração forte com Figma, custo recorrente.
+- **Supernova**: similar ao Zeroheight, com sync bidirecional Figma ↔ doc.
+- **Manter custom**: evoluir o `sync-docs.mjs` com editor WYSIWYG interno.
+
+Decisão aguarda: volume de contribuição, necessidade de editores não-técnicos, orçamento. Por ora, o fluxo MD → HTML via `marked` no `sync-docs.mjs` atende.
+
+### Sincronização automática de tokens (webhook ou agendado)
+
+A Fase 7 implementou sync manual via `workflow_dispatch`. Evoluir pra:
+
+- Webhook do Figma disparando o workflow quando Variables são modificadas.
+- Ou agendamento diário (cron) pra detectar mudanças e abrir PR.
+
+Só se o disparo manual virar gargalo.
+
+### Sincronização de textos Figma ↔ site
+
+A Fase 7 original previa. Substituída pela decisão de reduzir doc textual do Figma (item acima). Se no futuro houver demanda real de ter textos idênticos em ambos os lados, reavaliar.
 
 ## Baixa prioridade
 
 ### Storybook
 
-Componente inventory marca como pendente. Hoje o site cumpre o papel de vitrine interativa. Só implementar se houver demanda explícita de time Dev consumidor.
+Componente inventory marca como pendente. Hoje o site cumpre o papel de vitrine interativa. Só implementar se houver demanda explícita de time Dev consumidor. Integração com os tokens DTCG já gerados (formato padrão de import), sem reinventar.
 
 ### MCP próprio do design system
 
@@ -36,6 +65,6 @@ Pacote nunca foi publicado. Decidir quando (e com qual nome de escopo) fazer o p
 
 Você mencionou que páginas vazias (Icons, Grids, Images, Templates) e resíduos nas páginas de componente (SECTION e `image 1` em Input Text, INSTANCE soltas em Button, `Frame 1` em Textarea) estão em uso para experimentos. Quando terminar os testes, decidir se preenche ou remove.
 
-### Contraste dos 65 warnings de `tokens-verify`
+### Resolução de conflitos inteligente no `sync-tokens-from-figma`
 
-Tokens em JSON sem CSS custom property equivalente — sobretudo overlays (`foundation.color.overlay.*`), tipografia e `semantic.typography.control.*`. Investigar caso a caso se deveriam gerar CSS var ou se a omissão é intencional (tokens intermediários).
+Hoje o script loga e pede intervenção quando encontra ambiguidade (ex: variável renomeada no Figma vs variável nova; alias quebrado). Evoluir pra sugerir ação com heurística (ex: "detectei que `color/primary/toned` pode ter virado `brand/toned/default` com base em similaridade de valor; aplicar?").

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,13 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.8]</h2>
+<h3>Alterado</h3>
+<ul>
+<li>ADR-003 reescrita. A versão anterior declarava Git como fonte de verdade para tokens; a revisão reposiciona <strong>Figma Variables como a autoridade canônica</strong> dos valores de token. Git (<code>tokens/**/*.json</code>) passa a ser &quot;consolidação derivada em DTCG&quot; em vez de source. Fluxo canônico: Figma → sync manual → JSON → CSS → site. Decisão tomada em 21/04/2026 alinhando a prática à intenção do time (designer decide; dev consolida).</li>
+<li>CLAUDE.md: seção &quot;Como a pipeline funciona&quot; atualizada com o novo fluxo. Regras de ouro adicionadas: não editar <code>tokens/*.json</code> à mão, sempre passar pelo Figma. Lista de scripts em &quot;Ferramentas&quot; lista <code>sync:tokens-from-figma</code> (a ser implementado no próximo PR).</li>
+<li>Backlog reestruturado: item &quot;Sincronização automatizada Figma ↔ site&quot; substituído por &quot;Reduzir documentação textual do Figma&quot; (decisão concreta do time). Adicionados itens &quot;Futuro do site de documentação&quot; (Astro/Zeroheight/Supernova), &quot;Resolução de conflitos inteligente&quot; e &quot;Sincronização automática de tokens&quot; (evoluções futuras).</li>
+</ul>
 <h2>[0.5.7]</h2>
 <h3>Adicionado</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.7**
+> Versão atual: **0.5.8**
 
 ## Status geral
 
@@ -60,7 +60,7 @@
 |-----|--------|--------|
 | ADR-001 | Migração da arquitetura de tokens para Foundation→Semantic→Component com DTCG + Style Dictionary | Aceita |
 | ADR-002 | Stack agnóstica — HTML + CSS + vanilla JS como base | Aceita |
-| ADR-003 | Figma como autoridade de design, Git como autoridade de tokens/código | Aceita |
+| ADR-003 | Figma como origem canônica de tokens, Git como consolidação | Aceita — Revisada em 0.5.8 |
 | ADR-004 | WCAG 2.2 AA como padrão de acessibilidade | Aceita — Implementada em 0.5.0 |
 | ADR-005 | Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2) |
 | ADR-006 | Tokens semânticos de controle para dimensões e tipografia compartilhadas entre controles interativos | Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3) |

--- a/docs/decisions/ADR-003-fontes-verdade.md
+++ b/docs/decisions/ADR-003-fontes-verdade.md
@@ -1,36 +1,91 @@
-# ADR-003: Figma como autoridade de design, Git como autoridade de tokens/código
+# ADR-003: Figma como origem canônica de tokens, Git como consolidação
 
-**Data:** 2026-04-14
-**Status:** Aceita
+**Data:** 2026-04-14 (original) · 2026-04-21 (revisada)
+**Status:** Aceita — Revisada em 0.5.8
 
 ## Contexto
 
-O DS é mantido em dois artefatos: Figma (componentes visuais, variables) e Git (CSS, tokens JSON, docs). Precisa haver clareza sobre qual é a fonte de verdade para cada tipo de informação.
+A versão original deste ADR (abril/2026) declarava Git como fonte de verdade para tokens (JSON) e Figma como consumidor. A direção implementada seguia essa convenção: editar JSON → `build-tokens.mjs` gera CSS → Figma era atualizado manualmente.
+
+Revisitando esta decisão em 21/04/2026 com o time, ficou claro que a direção correta do fluxo é o oposto: **as decisões de design nascem no Figma**, onde o designer explora, testa, valida e fecha valores de cor, spacing, tipografia. Essas decisões precisam virar código e documentação, não o contrário. Forçar o desenvolvedor a editar JSON e depois "sincronizar" o Figma quebra a cadeia natural designer → dev e distancia a fonte real (decisões humanas em uma ferramenta visual) da representação técnica.
+
+Esta revisão alinha a ADR à realidade desejada: **Figma Variables são a autoridade** para valores de token. JSON em `tokens/` é uma **consolidação** — um contrato em formato transportável (DTCG) que vira código, documentação e futuramente Storybook.
 
 ## Decisão
 
-- **Git** é a fonte de verdade para: tokens (JSONs), código CSS, documentação, ADRs, package.json
-- **Figma** é a fonte de verdade para: design visual de componentes (auto-layout, variantes, properties), documentação visual (pages de componentes)
-- **Tokens** são o contrato entre os dois: definidos em JSON no Git, espelhados como Variables no Figma
-- **Claude Code + use_figma** é a ferramenta de construção nos dois lados
-- Sempre que houver divergência entre Figma e CSS, o Figma prevalece para visual e o Git prevalece para valores de token
+### Fontes de verdade
+
+- **Figma Variables**: fonte canônica de todos os valores de token (cor, spacing, tipografia, radius, shadow, stroke, opacity, motion, z-index). Arquivo `PRYS2kL7VdC1MtVWfZvuDN`.
+- **Figma (frames e componentes)**: fonte canônica do design visual (auto-layout, variantes, properties, anatomy).
+- **Git (`tokens/**/*.json`)**: consolidação derivada do Figma em formato DTCG. Versionado, transportável entre plataformas.
+- **Git (`css/`, `docs/`, ADRs, código)**: fonte canônica do código e da documentação textual. Inclui `CHANGELOG.md`, `CONTRIBUTING.md`, ADRs, schemas.
+
+### Fluxo explícito
+
+```
+Figma Variables (autoridade de valor)
+       │
+       │ npm run sync:tokens-from-figma (manual, abre PR)
+       ▼
+tokens/**/*.json (DTCG, consolidação em Git)
+       │
+       │ npm run build:tokens (automático no CI)
+       ▼
+css/tokens/generated/*.css
+       │
+       │ @import em design-system.css
+       ▼
+css/components/*.css (consumo nos 18 componentes)
+       │
+       ▼
+site em docs/ + Storybook (futuro)
+```
+
+### Regras operacionais
+
+1. Mudanças de token **começam no Figma**. Designer edita a Variable, valida visualmente.
+2. Quando o designer decide que o conjunto de mudanças está fechado, alguém roda `npm run sync:tokens-from-figma` (dry-run por padrão, `--write` pra aplicar). Dispara em comando manual — não é automático.
+3. O script abre um PR com o diff pros JSONs. Revisão mínima antes do merge (nomes novos, remoções inesperadas, valores discrepantes).
+4. Após o merge, `build-tokens.mjs` regenera o CSS. CI publica o site.
+5. **Nunca editar `tokens/*.json` à mão** num commit normal. JSONs são derivados. A exceção é em PRs do próprio script de sync, onde a edição é gerada automaticamente e revisada como diff.
+6. Mudanças visuais de componente (não de token) continuam acontecendo no Figma normalmente. CSS de componente é atualizado manualmente pra refletir.
+
+### Ferramentas
+
+- **MCP remoto do Figma** (`use_figma`): canal pelo qual o script acessa as Variables. Já autenticado como UXIN Pro/Expert.
+- **`scripts/sync-tokens-from-figma.mjs`**: o script de sync. Dry-run por padrão.
+- **`scripts/tokens-verify.mjs`**: passa a interpretar divergências orientadas — Figma como autoridade.
 
 ## Verificação automatizada
 
-A partir de 0.5.1, a coerência entre Figma Variables e JSONs em `tokens/` passa a ser verificada por script em CI:
+`scripts/tokens-verify.mjs` classifica divergências em três categorias:
 
-- `scripts/tokens-verify.mjs` compara nome e valor resolvido de cada variável Figma contra o JSON correspondente, por modo.
-- Workflow `.github/workflows/verify-tokens.yml` roda em pull requests e push para main. Divergências são reportadas em três formatos: terminal, `docs/api/tokens-sync.json`, e página `docs/tokens-sync.html`.
-- Na primeira fase, o workflow não falha em divergência (fase de descoberta). Depois de estabilizar, passa a falhar o CI.
+- **NEEDS_SYNC** (warning): Figma tem uma Variable que o JSON ainda não representa. Rodar `sync:tokens-from-figma` resolve.
+- **DRIFT_FROM_SOURCE** (erro): JSON tem um token que não existe no Figma. Indica edição manual do JSON ou Variable deletada no Figma sem sync.
+- **VALUE_DRIFT** (erro): mesmo nome, valor diferente. Sincronizar.
+
+O workflow `.github/workflows/verify-tokens.yml` roda em pull requests e push pra main. Em 0.5.8, a interpretação fica em warning em todos os casos (fase de adaptação). Depois de duas semanas estáveis, `DRIFT_FROM_SOURCE` e `VALUE_DRIFT` passam a falhar o CI.
 
 ## Consequências
 
-- Mudanças de token: editar JSON → rodar Style Dictionary → atualizar Figma via use_figma.
-- Mudanças visuais de componente: ajustar no Figma → atualizar CSS para refletir.
-- A verificação automatizada torna a regra executável — deixa de depender de disciplina manual.
+- A "porta de entrada" para mudanças de tokens passa a ser o Figma. Fluxo natural pro designer.
+- Desenvolvedores que quiserem sugerir uma mudança de token abrem uma issue ou negociam com design. Não têm permissão de editar o JSON diretamente (convenção, não bloqueio técnico).
+- O CI continua rápido e simples: build-tokens depende só do JSON do repo, igual antes. Novo script é invocado manualmente, não bloqueia deploys.
+- A versão "oficial" dos tokens é a que está no Git em `tokens/` — o Figma é a autoridade mas o Git é o backup imutável e o ponto de consumo pra todo o resto da cadeia.
 
 ## Alternativas consideradas
 
-**Git como única fonte:** Descartado. Gerar componentes Figma programaticamente produz resultados estruturalmente fracos para auto-layout e variantes complexas.
+**Manter Git como source (ADR-003 original, pré-revisão).** Descartada porque separa a decisão (Figma) da representação canônica (JSON), forçando sincronização em ordem não natural.
 
-**Figma como única fonte:** Descartado. Figma não é sistema de controle de versão e tokens em Variables não são facilmente transformáveis para múltiplas plataformas.
+**Tokens Studio como intermediário no Figma.** Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 620 Variables do formato nativo pra dentro do plugin, ajustar `build-tokens.mjs` pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).
+
+**Plugin Figma custom.** Descartada por ROI. Desenvolvimento + manutenção maior que o script via MCP pra o mesmo resultado funcional no cenário atual.
+
+**Bidirecional automático (webhook Figma).** Descartada pra início. Manual garante controle e revisão. Se o fluxo manual virar gargalo, reavaliar.
+
+## Referências
+
+- [ADR-001](./ADR-001-migracao-tokens.md) — Migração de tokens para DTCG + Style Dictionary.
+- [ADR-011](./ADR-011-renaming-tokens-semanticos-de-cor.md) — Renaming semântico que consolidou a estrutura atual do JSON.
+- `scripts/sync-tokens-from-figma.mjs` — implementação do sync (a partir de 0.5.8).
+- `scripts/tokens-verify.mjs` — verificador com interpretação revisada (a partir de 0.5.8).

--- a/docs/decisions/adr-003-fontes-verdade.html
+++ b/docs/decisions/adr-003-fontes-verdade.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ADR-003 — Figma como autoridade de design, Git como autoridade de tokens/código — Design System</title>
+  <title>ADR-003 — Figma como origem canônica de tokens, Git como consolidação — Design System</title>
   <link rel="stylesheet" href="../../css/design-system.css">
   <link rel="stylesheet" href="../layout.css">
   <style>
@@ -61,8 +61,8 @@
 
 <main class="ds-main">
   <div class="ds-section">
-    <h1 class="ds-section__title">ADR-003 — Figma como autoridade de design, Git como autoridade de tokens/código</h1>
-    <p class="ds-section__subtitle">Status: <strong>Aceita</strong> · Data: 2026-04-14</p>
+    <h1 class="ds-section__title">ADR-003 — Figma como origem canônica de tokens, Git como consolidação</h1>
+    <p class="ds-section__subtitle">Status: <strong>Aceita — Revisada em 0.5.8</strong> · Data: 2026-04-14 (original) · 2026-04-21 (revisada)</p>
   </div>
 
   <div class="ds-md-generated-banner">
@@ -70,34 +70,80 @@
   </div>
 
   <div class="ds-md-content">
-<p><strong>Data:</strong> 2026-04-14
-<strong>Status:</strong> Aceita</p>
+<p><strong>Data:</strong> 2026-04-14 (original) · 2026-04-21 (revisada)
+<strong>Status:</strong> Aceita — Revisada em 0.5.8</p>
 <h2>Contexto</h2>
-<p>O DS é mantido em dois artefatos: Figma (componentes visuais, variables) e Git (CSS, tokens JSON, docs). Precisa haver clareza sobre qual é a fonte de verdade para cada tipo de informação.</p>
+<p>A versão original deste ADR (abril/2026) declarava Git como fonte de verdade para tokens (JSON) e Figma como consumidor. A direção implementada seguia essa convenção: editar JSON → <code>build-tokens.mjs</code> gera CSS → Figma era atualizado manualmente.</p>
+<p>Revisitando esta decisão em 21/04/2026 com o time, ficou claro que a direção correta do fluxo é o oposto: <strong>as decisões de design nascem no Figma</strong>, onde o designer explora, testa, valida e fecha valores de cor, spacing, tipografia. Essas decisões precisam virar código e documentação, não o contrário. Forçar o desenvolvedor a editar JSON e depois &quot;sincronizar&quot; o Figma quebra a cadeia natural designer → dev e distancia a fonte real (decisões humanas em uma ferramenta visual) da representação técnica.</p>
+<p>Esta revisão alinha a ADR à realidade desejada: <strong>Figma Variables são a autoridade</strong> para valores de token. JSON em <code>tokens/</code> é uma <strong>consolidação</strong> — um contrato em formato transportável (DTCG) que vira código, documentação e futuramente Storybook.</p>
 <h2>Decisão</h2>
+<h3>Fontes de verdade</h3>
 <ul>
-<li><strong>Git</strong> é a fonte de verdade para: tokens (JSONs), código CSS, documentação, ADRs, package.json</li>
-<li><strong>Figma</strong> é a fonte de verdade para: design visual de componentes (auto-layout, variantes, properties), documentação visual (pages de componentes)</li>
-<li><strong>Tokens</strong> são o contrato entre os dois: definidos em JSON no Git, espelhados como Variables no Figma</li>
-<li><strong>Claude Code + use_figma</strong> é a ferramenta de construção nos dois lados</li>
-<li>Sempre que houver divergência entre Figma e CSS, o Figma prevalece para visual e o Git prevalece para valores de token</li>
+<li><strong>Figma Variables</strong>: fonte canônica de todos os valores de token (cor, spacing, tipografia, radius, shadow, stroke, opacity, motion, z-index). Arquivo <code>PRYS2kL7VdC1MtVWfZvuDN</code>.</li>
+<li><strong>Figma (frames e componentes)</strong>: fonte canônica do design visual (auto-layout, variantes, properties, anatomy).</li>
+<li><strong>Git (<code>tokens/**/*.json</code>)</strong>: consolidação derivada do Figma em formato DTCG. Versionado, transportável entre plataformas.</li>
+<li><strong>Git (<code>css/</code>, <code>docs/</code>, ADRs, código)</strong>: fonte canônica do código e da documentação textual. Inclui <code>CHANGELOG.md</code>, <code>CONTRIBUTING.md</code>, ADRs, schemas.</li>
+</ul>
+<h3>Fluxo explícito</h3>
+<pre><code>Figma Variables (autoridade de valor)
+       │
+       │ npm run sync:tokens-from-figma (manual, abre PR)
+       ▼
+tokens/**/*.json (DTCG, consolidação em Git)
+       │
+       │ npm run build:tokens (automático no CI)
+       ▼
+css/tokens/generated/*.css
+       │
+       │ @import em design-system.css
+       ▼
+css/components/*.css (consumo nos 18 componentes)
+       │
+       ▼
+site em docs/ + Storybook (futuro)
+</code></pre>
+<h3>Regras operacionais</h3>
+<ol>
+<li>Mudanças de token <strong>começam no Figma</strong>. Designer edita a Variable, valida visualmente.</li>
+<li>Quando o designer decide que o conjunto de mudanças está fechado, alguém roda <code>npm run sync:tokens-from-figma</code> (dry-run por padrão, <code>--write</code> pra aplicar). Dispara em comando manual — não é automático.</li>
+<li>O script abre um PR com o diff pros JSONs. Revisão mínima antes do merge (nomes novos, remoções inesperadas, valores discrepantes).</li>
+<li>Após o merge, <code>build-tokens.mjs</code> regenera o CSS. CI publica o site.</li>
+<li><strong>Nunca editar <code>tokens/*.json</code> à mão</strong> num commit normal. JSONs são derivados. A exceção é em PRs do próprio script de sync, onde a edição é gerada automaticamente e revisada como diff.</li>
+<li>Mudanças visuais de componente (não de token) continuam acontecendo no Figma normalmente. CSS de componente é atualizado manualmente pra refletir.</li>
+</ol>
+<h3>Ferramentas</h3>
+<ul>
+<li><strong>MCP remoto do Figma</strong> (<code>use_figma</code>): canal pelo qual o script acessa as Variables. Já autenticado como UXIN Pro/Expert.</li>
+<li><strong><code>scripts/sync-tokens-from-figma.mjs</code></strong>: o script de sync. Dry-run por padrão.</li>
+<li><strong><code>scripts/tokens-verify.mjs</code></strong>: passa a interpretar divergências orientadas — Figma como autoridade.</li>
 </ul>
 <h2>Verificação automatizada</h2>
-<p>A partir de 0.5.1, a coerência entre Figma Variables e JSONs em <code>tokens/</code> passa a ser verificada por script em CI:</p>
+<p><code>scripts/tokens-verify.mjs</code> classifica divergências em três categorias:</p>
 <ul>
-<li><code>scripts/tokens-verify.mjs</code> compara nome e valor resolvido de cada variável Figma contra o JSON correspondente, por modo.</li>
-<li>Workflow <code>.github/workflows/verify-tokens.yml</code> roda em pull requests e push para main. Divergências são reportadas em três formatos: terminal, <code>docs/api/tokens-sync.json</code>, e página <code>docs/tokens-sync.html</code>.</li>
-<li>Na primeira fase, o workflow não falha em divergência (fase de descoberta). Depois de estabilizar, passa a falhar o CI.</li>
+<li><strong>NEEDS_SYNC</strong> (warning): Figma tem uma Variable que o JSON ainda não representa. Rodar <code>sync:tokens-from-figma</code> resolve.</li>
+<li><strong>DRIFT_FROM_SOURCE</strong> (erro): JSON tem um token que não existe no Figma. Indica edição manual do JSON ou Variable deletada no Figma sem sync.</li>
+<li><strong>VALUE_DRIFT</strong> (erro): mesmo nome, valor diferente. Sincronizar.</li>
 </ul>
+<p>O workflow <code>.github/workflows/verify-tokens.yml</code> roda em pull requests e push pra main. Em 0.5.8, a interpretação fica em warning em todos os casos (fase de adaptação). Depois de duas semanas estáveis, <code>DRIFT_FROM_SOURCE</code> e <code>VALUE_DRIFT</code> passam a falhar o CI.</p>
 <h2>Consequências</h2>
 <ul>
-<li>Mudanças de token: editar JSON → rodar Style Dictionary → atualizar Figma via use_figma.</li>
-<li>Mudanças visuais de componente: ajustar no Figma → atualizar CSS para refletir.</li>
-<li>A verificação automatizada torna a regra executável — deixa de depender de disciplina manual.</li>
+<li>A &quot;porta de entrada&quot; para mudanças de tokens passa a ser o Figma. Fluxo natural pro designer.</li>
+<li>Desenvolvedores que quiserem sugerir uma mudança de token abrem uma issue ou negociam com design. Não têm permissão de editar o JSON diretamente (convenção, não bloqueio técnico).</li>
+<li>O CI continua rápido e simples: build-tokens depende só do JSON do repo, igual antes. Novo script é invocado manualmente, não bloqueia deploys.</li>
+<li>A versão &quot;oficial&quot; dos tokens é a que está no Git em <code>tokens/</code> — o Figma é a autoridade mas o Git é o backup imutável e o ponto de consumo pra todo o resto da cadeia.</li>
 </ul>
 <h2>Alternativas consideradas</h2>
-<p><strong>Git como única fonte:</strong> Descartado. Gerar componentes Figma programaticamente produz resultados estruturalmente fracos para auto-layout e variantes complexas.</p>
-<p><strong>Figma como única fonte:</strong> Descartado. Figma não é sistema de controle de versão e tokens em Variables não são facilmente transformáveis para múltiplas plataformas.</p>
+<p><strong>Manter Git como source (ADR-003 original, pré-revisão).</strong> Descartada porque separa a decisão (Figma) da representação canônica (JSON), forçando sincronização em ordem não natural.</p>
+<p><strong>Tokens Studio como intermediário no Figma.</strong> Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 620 Variables do formato nativo pra dentro do plugin, ajustar <code>build-tokens.mjs</code> pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).</p>
+<p><strong>Plugin Figma custom.</strong> Descartada por ROI. Desenvolvimento + manutenção maior que o script via MCP pra o mesmo resultado funcional no cenário atual.</p>
+<p><strong>Bidirecional automático (webhook Figma).</strong> Descartada pra início. Manual garante controle e revisão. Se o fluxo manual virar gargalo, reavaliar.</p>
+<h2>Referências</h2>
+<ul>
+<li><a href="./ADR-001-migracao-tokens.md">ADR-001</a> — Migração de tokens para DTCG + Style Dictionary.</li>
+<li><a href="./ADR-011-renaming-tokens-semanticos-de-cor.md">ADR-011</a> — Renaming semântico que consolidou a estrutura atual do JSON.</li>
+<li><code>scripts/sync-tokens-from-figma.mjs</code> — implementação do sync (a partir de 0.5.8).</li>
+<li><code>scripts/tokens-verify.mjs</code> — verificador com interpretação revisada (a partir de 0.5.8).</li>
+</ul>
 
   </div>
 </main>

--- a/docs/decisions/index.html
+++ b/docs/decisions/index.html
@@ -77,7 +77,7 @@
 <tbody>
 <tr><td><a href="adr-001-migracao-tokens.html">ADR-001</a></td><td>Migração da arquitetura de tokens para Foundation→Semantic→Component com DTCG + Style Dictionary</td><td>Aceita</td><td>2026-04-14</td></tr>
 <tr><td><a href="adr-002-stack-agnostica.html">ADR-002</a></td><td>Stack agnóstica — HTML + CSS + vanilla JS como base</td><td>Aceita</td><td>2026-04-14</td></tr>
-<tr><td><a href="adr-003-fontes-verdade.html">ADR-003</a></td><td>Figma como autoridade de design, Git como autoridade de tokens/código</td><td>Aceita</td><td>2026-04-14</td></tr>
+<tr><td><a href="adr-003-fontes-verdade.html">ADR-003</a></td><td>Figma como origem canônica de tokens, Git como consolidação</td><td>Aceita — Revisada em 0.5.8</td><td>2026-04-14 (original) · 2026-04-21 (revisada)</td></tr>
 <tr><td><a href="adr-004-wcag.html">ADR-004</a></td><td>WCAG 2.2 AA como padrão de acessibilidade</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-14</td></tr>
 <tr><td><a href="adr-005-brand-foundation-e-estados-explicitos.html">ADR-005</a></td><td>Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica</td><td>Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2)</td><td>2026-04-14</td></tr>
 <tr><td><a href="adr-006-semantic-control-tokens.html">ADR-006</a></td><td>Tokens semânticos de controle para dimensões e tipografia compartilhadas entre controles interativos</td><td>Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3)</td><td>2026-04-15</td></tr>

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.7**
+> Versão atual: **0.5.8**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.7 |
+| Versão | 0.5.8 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -92,7 +92,7 @@ semantic.typography.*
 
 - **ADR-001** — Migração da arquitetura de tokens para Foundation→Semantic→Component com DTCG + Style Dictionary (Aceita)
 - **ADR-002** — Stack agnóstica — HTML + CSS + vanilla JS como base (Aceita)
-- **ADR-003** — Figma como autoridade de design, Git como autoridade de tokens/código (Aceita)
+- **ADR-003** — Figma como origem canônica de tokens, Git como consolidação (Aceita — Revisada em 0.5.8)
 - **ADR-004** — WCAG 2.2 AA como padrão de acessibilidade (Aceita — Implementada em 0.5.0)
 - **ADR-005** — Brand como camada foundation, estados explícitos no semantic, e limpeza tipográfica (Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.2))
 - **ADR-006** — Tokens semânticos de controle para dimensões e tipografia compartilhadas entre controles interativos (Aceita — Implementada em 0.5.0 (fechamento formal em 0.5.3))

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.7 -->v0.5.7</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.8 -->v0.5.8</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",


### PR DESCRIPTION
## Summary

ADR-003 reescrita. A versão anterior declarava Git como source of truth pra tokens. Decisão revisada: **Figma Variables** são a autoridade; Git é consolidação derivada via sync manual.

Atualizações correlatas: CLAUDE.md (pipeline + scripts), backlog (itens futuros), CHANGELOG (0.5.8).

Este PR é só documental. O script de sync + workflow CI + verify:tokens revisado ficam em PR separado pra facilitar revisão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)