### PR TITLE
feat(tokens): sync Figma → JSON via script + workflow + verify refinado

### DIFF
--- a/.github/workflows/sync-tokens-from-figma.yml
+++ b/.github/workflows/sync-tokens-from-figma.yml
@@ -1,0 +1,86 @@
+name: Sync tokens from Figma
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run in dry-run mode (report only, no file changes)"
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run sync (${{ inputs.dry-run && 'dry-run' || 'write' }})
+        id: sync
+        env:
+          FIGMA_PAT: ${{ secrets.FIGMA_PAT }}
+        run: |
+          set +e
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            node scripts/sync-tokens-from-figma.mjs | tee /tmp/sync-output.txt
+          else
+            node scripts/sync-tokens-from-figma.mjs --write | tee /tmp/sync-output.txt
+          fi
+          code=$?
+          echo "exit_code=$code" >> $GITHUB_OUTPUT
+          # Captura relatório em variável de ambiente multi-linha
+          {
+            echo "report<<SYNC_REPORT_EOF"
+            cat /tmp/sync-output.txt
+            echo "SYNC_REPORT_EOF"
+          } >> $GITHUB_OUTPUT
+          exit 0
+
+      - name: Check for changes
+        id: diff
+        if: inputs.dry-run == false
+        run: |
+          if [ -n "$(git status --porcelain tokens/ css/tokens/generated/ docs/)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: inputs.dry-run == false && steps.diff.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sync/tokens-from-figma-${{ github.run_id }}
+          title: "chore(tokens): sync Figma Variables → JSON"
+          body: |
+            Automated Figma → JSON sync via `scripts/sync-tokens-from-figma.mjs --write`.
+
+            ```
+            ${{ steps.sync.outputs.report }}
+            ```
+
+            Review the diff carefully before merging.
+          commit-message: |
+            chore(tokens): sync Figma Variables → JSON
+
+            Automated via .github/workflows/sync-tokens-from-figma.yml.
+
+      - name: Report dry-run
+        if: inputs.dry-run == true
+        run: |
+          echo "::notice::Dry-run complete. See logs above. Re-run with dry-run=false to apply."
+
+      - name: Report no changes
+        if: inputs.dry-run == false && steps.diff.outputs.changes == 'false'
+        run: |
+          echo "::notice::Figma and JSON are already in sync. Nothing to commit."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.6.0]
+
+### Adicionado
+- **`scripts/sync-tokens-from-figma.mjs`** — canal oficial Figma → JSON, alinhado à ADR-003 revisada (Figma como autoridade). Dry-run por padrão, `--write` aplica. Apenas `VALUE_DRIFT` é aplicado automaticamente; `NEW_IN_FIGMA` e `MISSING_IN_FIGMA` exigem ação manual (prevenção de criação/remoção não-intencional).
+- **`scripts/lib/figma-dtcg.mjs`** — módulo compartilhado com lógica de fetch Figma, conversão Figma→DTCG e comparação. Reutilizado por `sync-tokens-from-figma.mjs` e `tokens-verify.mjs`.
+- **`.github/workflows/sync-tokens-from-figma.yml`** — workflow manual (`workflow_dispatch`). Suporta dry-run opcional via input. Em modo write, abre PR automático com o diff no corpo. Exige secret `FIGMA_PAT`.
+- Novos npm scripts: `sync:tokens-from-figma` (dry-run) e `sync:tokens-from-figma:write` (aplica).
+
+### Alterado
+- **`scripts/tokens-verify.mjs`** — comparação Figma↔JSON passa da categorização genérica anterior para as três categorias do ADR-003 revisada: `NEEDS_SYNC` (warning), `DRIFT_FROM_SOURCE` (erro) e `VALUE_DRIFT` (erro). Resolução completa de aliases Figma, normalização de dimensões (px/rem equivalentes), suporte a modos Light/Dark separados. Na fase de adaptação (14 dias), todas as categorias ficam como warning — depois `DRIFT_FROM_SOURCE` e `VALUE_DRIFT` passam a falhar o CI.
+
 ## [0.5.8]
 
 ### Alterado

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T14:32:42.029Z",
-  "version": "0.5.8",
+  "generatedAt": "2026-04-21T15:02:06.285Z",
+  "version": "0.6.0",
   "count": 11,
   "adrs": [
     {

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T14:32:42.029Z",
-  "version": "0.5.8",
+  "generatedAt": "2026-04-21T15:02:06.285Z",
+  "version": "0.6.0",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T14:32:42.029Z",
-  "version": "0.5.8",
+  "generatedAt": "2026-04-21T15:02:06.285Z",
+  "version": "0.6.0",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T14:32:42.362Z",
+  "generatedAt": "2026-04-21T15:02:06.744Z",
   "totals": {
     "jsonTokens": 632,
     "sharedTokens": 368,
@@ -13,8 +13,14 @@
     "jsonVsCss": [],
     "jsonVsFigma": {
       "skipped": true,
-      "reason": "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat>.",
-      "divergences": []
+      "reason": "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat> ou configure o secret no CI.",
+      "divergences": [],
+      "counts": {
+        "NEEDS_SYNC": 0,
+        "DRIFT_FROM_SOURCE": 0,
+        "VALUE_DRIFT": 0,
+        "ALIAS_BROKEN": 0
+      }
     }
   }
 }

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T14:32:42.029Z",
-  "version": "0.5.8",
+  "generatedAt": "2026-04-21T15:02:06.285Z",
+  "version": "0.6.0",
   "counts": {
     "foundation": 231,
     "semanticLight": 132,

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,18 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.6.0]</h2>
+<h3>Adicionado</h3>
+<ul>
+<li><strong><code>scripts/sync-tokens-from-figma.mjs</code></strong> — canal oficial Figma → JSON, alinhado à ADR-003 revisada (Figma como autoridade). Dry-run por padrão, <code>--write</code> aplica. Apenas <code>VALUE_DRIFT</code> é aplicado automaticamente; <code>NEW_IN_FIGMA</code> e <code>MISSING_IN_FIGMA</code> exigem ação manual (prevenção de criação/remoção não-intencional).</li>
+<li><strong><code>scripts/lib/figma-dtcg.mjs</code></strong> — módulo compartilhado com lógica de fetch Figma, conversão Figma→DTCG e comparação. Reutilizado por <code>sync-tokens-from-figma.mjs</code> e <code>tokens-verify.mjs</code>.</li>
+<li><strong><code>.github/workflows/sync-tokens-from-figma.yml</code></strong> — workflow manual (<code>workflow_dispatch</code>). Suporta dry-run opcional via input. Em modo write, abre PR automático com o diff no corpo. Exige secret <code>FIGMA_PAT</code>.</li>
+<li>Novos npm scripts: <code>sync:tokens-from-figma</code> (dry-run) e <code>sync:tokens-from-figma:write</code> (aplica).</li>
+</ul>
+<h3>Alterado</h3>
+<ul>
+<li><strong><code>scripts/tokens-verify.mjs</code></strong> — comparação Figma↔JSON passa da categorização genérica anterior para as três categorias do ADR-003 revisada: <code>NEEDS_SYNC</code> (warning), <code>DRIFT_FROM_SOURCE</code> (erro) e <code>VALUE_DRIFT</code> (erro). Resolução completa de aliases Figma, normalização de dimensões (px/rem equivalentes), suporte a modos Light/Dark separados. Na fase de adaptação (14 dias), todas as categorias ficam como warning — depois <code>DRIFT_FROM_SOURCE</code> e <code>VALUE_DRIFT</code> passam a falhar o CI.</li>
+</ul>
 <h2>[0.5.8]</h2>
 <h3>Alterado</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.8**
+> Versão atual: **0.6.0**
 
 ## Status geral
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.5.8. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.6.0. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -305,6 +305,17 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em `docs/process-versioning.html`.
 
 ## [Não publicado]
+
+## [0.6.0]
+
+### Adicionado
+- **`scripts/sync-tokens-from-figma.mjs`** — canal oficial Figma → JSON, alinhado à ADR-003 revisada (Figma como autoridade). Dry-run por padrão, `--write` aplica. Apenas `VALUE_DRIFT` é aplicado automaticamente; `NEW_IN_FIGMA` e `MISSING_IN_FIGMA` exigem ação manual (prevenção de criação/remoção não-intencional).
+- **`scripts/lib/figma-dtcg.mjs`** — módulo compartilhado com lógica de fetch Figma, conversão Figma→DTCG e comparação. Reutilizado por `sync-tokens-from-figma.mjs` e `tokens-verify.mjs`.
+- **`.github/workflows/sync-tokens-from-figma.yml`** — workflow manual (`workflow_dispatch`). Suporta dry-run opcional via input. Em modo write, abre PR automático com o diff no corpo. Exige secret `FIGMA_PAT`.
+- Novos npm scripts: `sync:tokens-from-figma` (dry-run) e `sync:tokens-from-figma:write` (aplica).
+
+### Alterado
+- **`scripts/tokens-verify.mjs`** — comparação Figma↔JSON passa da categorização genérica anterior para as três categorias do ADR-003 revisada: `NEEDS_SYNC` (warning), `DRIFT_FROM_SOURCE` (erro) e `VALUE_DRIFT` (erro). Resolução completa de aliases Figma, normalização de dimensões (px/rem equivalentes), suporte a modos Light/Dark separados. Na fase de adaptação (14 dias), todas as categorias ficam como warning — depois `DRIFT_FROM_SOURCE` e `VALUE_DRIFT` passam a falhar o CI.
 
 ## [0.5.8]
 
@@ -655,7 +666,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.8**
+> Versão atual: **0.6.0**
 
 ## Status geral
 
@@ -1141,13 +1152,13 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.8**
+> Versão atual: **0.6.0**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.8 |
+| Versão | 0.6.0 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -2581,6 +2592,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T14:32:42.196Z
-Versão: 0.5.8
+Gerado por scripts/build-llms.mjs em 2026-04-21T15:02:06.519Z
+Versão: 0.6.0
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.8. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.6.0. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -89,4 +89,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T14:32:42.196Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T15:02:06.519Z.

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.8**
+> Versão atual: **0.6.0**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.8 |
+| Versão | 0.6.0 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,7 +63,7 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T14:32:42.362Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T15:02:06.744Z</div>
       <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.8 -->v0.5.8</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.6.0 -->v0.6.0</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",
@@ -24,6 +24,8 @@
     "build:tokens": "node build-tokens.mjs",
     "sync:docs": "node scripts/sync-docs.mjs",
     "verify:tokens": "node scripts/tokens-verify.mjs",
+    "sync:tokens-from-figma": "node scripts/sync-tokens-from-figma.mjs",
+    "sync:tokens-from-figma:write": "node scripts/sync-tokens-from-figma.mjs --write",
     "build:api": "node scripts/build-api.mjs",
     "build:llms": "node scripts/build-llms.mjs",
     "build:all": "npm run build:tokens && npm run sync:docs && npm run build:api && npm run build:llms && npm run verify:tokens"

--- a/scripts/lib/figma-dtcg.mjs
+++ b/scripts/lib/figma-dtcg.mjs
@@ -1,0 +1,313 @@
+/**
+ * figma-dtcg.mjs — funções compartilhadas para ler Figma Variables e
+ * convertê-las no formato DTCG do repo. Usado por:
+ *   - scripts/sync-tokens-from-figma.mjs (sync Figma → JSON com --write)
+ *   - scripts/tokens-verify.mjs (verificação de coerência no CI)
+ *
+ * Direção canônica conforme ADR-003 revisada: Figma Variables são a
+ * autoridade. JSONs em tokens/ são consolidação derivada.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const FIGMA_FILE_KEY = "PRYS2kL7VdC1MtVWfZvuDN";
+
+// Prefixo do nome da variável Figma → arquivo em tokens/foundation/
+export const FOUNDATION_PREFIX_TO_FILE = {
+  color: "colors.json",
+  font: "typography.json",
+  spacing: "spacing.json",
+  radius: "radius.json",
+  opacity: "opacity.json",
+  border: "stroke.json",
+};
+
+// Brand tem 3 modos (Default/Ocean/Forest), só Default entra em foundation/brand.json.
+export const BRAND_MODE = "Default";
+// Component tem 1 modo "Default".
+export const COMPONENT_MODE = "Default";
+
+// ─── Figma REST API ──────────────────────────────────────────────────────────
+
+export async function fetchFigmaVariables(pat, fileKey = FIGMA_FILE_KEY) {
+  const url = `https://api.figma.com/v1/files/${fileKey}/variables/local`;
+  const res = await fetch(url, { headers: { "X-Figma-Token": pat } });
+  if (!res.ok) {
+    throw new Error(`Figma API ${res.status}: ${await res.text()}`);
+  }
+  const data = await res.json();
+  return data.meta;
+}
+
+// ─── Figma → DTCG conversion ─────────────────────────────────────────────────
+
+export function figmaNameToPath(figmaName) {
+  return figmaName.split("/").join(".");
+}
+
+export function colorToString(rgba) {
+  const { r, g, b, a } = rgba;
+  const to255 = (c) => Math.round(c * 255);
+  if (a < 0.999) {
+    return `rgba(${to255(r)}, ${to255(g)}, ${to255(b)}, ${parseFloat(a.toFixed(2))})`;
+  }
+  return (
+    "#" +
+    [r, g, b]
+      .map((c) => to255(c).toString(16).padStart(2, "0").toUpperCase())
+      .join("")
+  );
+}
+
+export function collectionToLayer(collection) {
+  if (!collection) return "unknown";
+  switch (collection.name) {
+    case "Foundation":
+      return "foundation";
+    case "Brand":
+      return "foundation";
+    case "Semantic":
+      return "semantic";
+    case "Component":
+      return "component";
+    default:
+      return collection.name.toLowerCase();
+  }
+}
+
+export function resolveValue(value, allVarsById, collectionsById) {
+  if (value == null) return null;
+
+  if (typeof value === "object" && value.type === "VARIABLE_ALIAS") {
+    const target = allVarsById[value.id];
+    if (!target) {
+      return { __error: "ALIAS_BROKEN", aliasId: value.id };
+    }
+    const targetColl = collectionsById[target.variableCollectionId];
+    const layer = collectionToLayer(targetColl);
+    const targetPath = figmaNameToPath(target.name);
+    return `{${layer}.${targetPath}}`;
+  }
+
+  if (typeof value === "object" && "r" in value && "g" in value && "b" in value) {
+    return colorToString(value);
+  }
+
+  return value;
+}
+
+export function mapDtcgType(figmaType) {
+  switch (figmaType) {
+    case "COLOR":
+      return "color";
+    case "FLOAT":
+      return "dimension";
+    case "STRING":
+      return "string";
+    case "BOOLEAN":
+      return "boolean";
+    default:
+      return "color";
+  }
+}
+
+/**
+ * Dado um Variable + collection, retorna o arquivo-alvo DTCG.
+ * Retorna { file, mode, semanticMulti? }. semanticMulti indica que
+ * gera em 2 arquivos (light.json e dark.json) — nesse caso, o caller
+ * trata separadamente.
+ */
+export function resolveTargetFile(variable, collection) {
+  if (!collection) return { file: null, mode: null };
+
+  if (collection.name === "Foundation") {
+    const prefix = variable.name.split("/")[0];
+    const file = FOUNDATION_PREFIX_TO_FILE[prefix];
+    return file ? { file: `foundation/${file}`, mode: "Value" } : { file: null, mode: null };
+  }
+
+  if (collection.name === "Brand") {
+    return { file: "foundation/brand.json", mode: BRAND_MODE };
+  }
+
+  if (collection.name === "Semantic") {
+    return { file: null, mode: null, semanticMulti: true };
+  }
+
+  if (collection.name === "Component") {
+    const prefix = variable.name.split("/")[0];
+    return { file: `component/${prefix}.json`, mode: COMPONENT_MODE };
+  }
+
+  return { file: null, mode: null };
+}
+
+/**
+ * Varre todas as Variables e constrói o estado esperado dos JSONs.
+ * Retorna { state, issues }:
+ *   state = { "foundation/colors.json": { "foundation.color.neutral.50": {$value,$type,$description} }, ... }
+ *   issues = [{ category: "ALIAS_BROKEN", token, mode, target }, ...]
+ */
+export function buildExpectedState(figmaMeta) {
+  const { variables, variableCollections } = figmaMeta;
+  const allVarsById = variables;
+  const collectionsById = variableCollections;
+  const issues = [];
+  const state = {};
+
+  for (const v of Object.values(variables)) {
+    const coll = collectionsById[v.variableCollectionId];
+    if (!coll) continue;
+    const layer = collectionToLayer(coll);
+    const canonicalPath = `${layer}.${figmaNameToPath(v.name)}`;
+    const target = resolveTargetFile(v, coll);
+
+    if (coll.name === "Semantic") {
+      for (const m of coll.modes) {
+        const file =
+          m.name === "Light" ? "semantic/light.json" :
+          m.name === "Dark" ? "semantic/dark.json" : null;
+        if (!file) continue;
+        const resolved = resolveValue(v.valuesByMode[m.modeId], allVarsById, collectionsById);
+        if (resolved && typeof resolved === "object" && resolved.__error) {
+          issues.push({ category: "ALIAS_BROKEN", token: canonicalPath, mode: m.name, target: resolved.aliasId });
+          continue;
+        }
+        if (!state[file]) state[file] = {};
+        state[file][canonicalPath] = {
+          $value: resolved,
+          $type: mapDtcgType(v.resolvedType),
+          ...(v.description ? { $description: v.description } : {}),
+        };
+      }
+      continue;
+    }
+
+    if (!target.file) continue;
+    const mode = coll.modes.find((m) => m.name === target.mode);
+    if (!mode) continue;
+    const resolved = resolveValue(v.valuesByMode[mode.modeId], allVarsById, collectionsById);
+    if (resolved && typeof resolved === "object" && resolved.__error) {
+      issues.push({ category: "ALIAS_BROKEN", token: canonicalPath, mode: target.mode, target: resolved.aliasId });
+      continue;
+    }
+    if (!state[target.file]) state[target.file] = {};
+    state[target.file][canonicalPath] = {
+      $value: resolved,
+      $type: mapDtcgType(v.resolvedType),
+      ...(v.description ? { $description: v.description } : {}),
+    };
+  }
+
+  return { state, issues };
+}
+
+// ─── Read current JSON state ────────────────────────────────────────────────
+
+export function flattenDtcg(obj, prefix = "", acc = {}) {
+  if (obj && typeof obj === "object" && "$value" in obj) {
+    acc[prefix] = obj;
+    return acc;
+  }
+  if (obj && typeof obj === "object") {
+    for (const [k, v] of Object.entries(obj)) {
+      if (k.startsWith("$")) continue;
+      flattenDtcg(v, prefix ? `${prefix}.${k}` : k, acc);
+    }
+  }
+  return acc;
+}
+
+export function readCurrentState(tokensDir) {
+  const state = {};
+  const readIfExists = (relFile) => {
+    const abs = path.join(tokensDir, relFile);
+    if (!fs.existsSync(abs)) return null;
+    return flattenDtcg(JSON.parse(fs.readFileSync(abs, "utf8")));
+  };
+  for (const f of Object.values(FOUNDATION_PREFIX_TO_FILE)) {
+    const rel = `foundation/${f}`;
+    const flat = readIfExists(rel);
+    if (flat) state[rel] = flat;
+  }
+  const brand = readIfExists("foundation/brand.json");
+  if (brand) state["foundation/brand.json"] = brand;
+  const light = readIfExists("semantic/light.json");
+  if (light) state["semantic/light.json"] = light;
+  const dark = readIfExists("semantic/dark.json");
+  if (dark) state["semantic/dark.json"] = dark;
+  const compDir = path.join(tokensDir, "component");
+  if (fs.existsSync(compDir)) {
+    for (const f of fs.readdirSync(compDir)) {
+      if (!f.endsWith(".json")) continue;
+      const rel = `component/${f}`;
+      const flat = readIfExists(rel);
+      if (flat) state[rel] = flat;
+    }
+  }
+  return state;
+}
+
+// ─── Compare ────────────────────────────────────────────────────────────────
+
+/**
+ * Converte valor de dimensão pra número em px. Retorna null se não for dimensão.
+ *   16     → 16 (Figma retorna números puros pra FLOAT)
+ *   "16px" → 16
+ *   "1rem" → 16
+ *   "1.5rem" → 24
+ */
+function asPx(v) {
+  if (typeof v === "number") return v;
+  if (typeof v !== "string") return null;
+  const s = v.trim().toLowerCase();
+  const rem = s.match(/^(-?[\d.]+)rem$/);
+  if (rem) return parseFloat(rem[1]) * 16;
+  const px = s.match(/^(-?[\d.]+)px$/);
+  if (px) return parseFloat(px[1]);
+  // Número puro em string
+  if (/^-?[\d.]+$/.test(s)) return parseFloat(s);
+  return null;
+}
+
+export function normalizeForCompare(v) {
+  if (v == null) return "";
+  // Tenta dimensão primeiro
+  const px = asPx(v);
+  if (px != null) return `px:${px}`;
+  if (typeof v === "object") return JSON.stringify(v);
+  let s = String(v).trim().toLowerCase();
+  if (/^#[0-9a-f]{3}$/.test(s)) s = "#" + s.slice(1).split("").map((c) => c + c).join("");
+  s = s.replace(/\s+/g, "");
+  return s;
+}
+
+/**
+ * Compara expected (Figma) vs actual (JSON). Retorna:
+ *   { VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA }
+ * Cada um é array de { file, token, figma?, json? }.
+ */
+export function compareStates(expected, actual) {
+  const diffs = { VALUE_DRIFT: [], NEW_IN_FIGMA: [], MISSING_IN_FIGMA: [] };
+  const allFiles = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  for (const file of allFiles) {
+    const exp = expected[file] || {};
+    const act = actual[file] || {};
+    const allKeys = new Set([...Object.keys(exp), ...Object.keys(act)]);
+    for (const key of allKeys) {
+      const e = exp[key];
+      const a = act[key];
+      if (e && !a) {
+        diffs.NEW_IN_FIGMA.push({ file, token: key, figma: e.$value });
+      } else if (!e && a) {
+        diffs.MISSING_IN_FIGMA.push({ file, token: key, json: a.$value });
+      } else if (e && a) {
+        if (normalizeForCompare(e.$value) !== normalizeForCompare(a.$value)) {
+          diffs.VALUE_DRIFT.push({ file, token: key, figma: e.$value, json: a.$value });
+        }
+      }
+    }
+  }
+  return diffs;
+}

--- a/scripts/sync-tokens-from-figma.mjs
+++ b/scripts/sync-tokens-from-figma.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * sync-tokens-from-figma.mjs — sincroniza Figma Variables para os arquivos
+ * JSON DTCG em `tokens/`.
+ *
+ * Direção canônica (ADR-003 revisada em 0.5.8): Figma é autoridade de
+ * valores de token. JSONs em tokens/ são consolidação derivada.
+ *
+ * Uso:
+ *   FIGMA_PAT=figd_xxx node scripts/sync-tokens-from-figma.mjs            (dry-run)
+ *   FIGMA_PAT=figd_xxx node scripts/sync-tokens-from-figma.mjs --write    (aplica VALUE_DRIFT e regenera CSS)
+ *
+ * Categorias (mesmas usadas em tokens-verify.mjs):
+ *   VALUE_DRIFT        mesmo nome, valor diferente. `--write` corrige.
+ *   NEW_IN_FIGMA       Figma tem, JSON não. `--write` não cria — ação manual.
+ *   MISSING_IN_FIGMA   JSON tem, Figma não. `--write` não deleta — ação manual.
+ *   ALIAS_BROKEN       variável Figma aponta pra ID inexistente.
+ *
+ * Exit codes:
+ *   0 — sem divergências ou `--write` bem sucedido.
+ *   1 — dry-run com divergências.
+ *   2 — erro de execução (PAT ausente, Figma erro, build falhou).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import {
+  fetchFigmaVariables,
+  buildExpectedState,
+  readCurrentState,
+  compareStates,
+} from "./lib/figma-dtcg.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const TOKENS_DIR = path.join(ROOT, "tokens");
+
+const FIGMA_PAT = process.env.FIGMA_PAT;
+const args = process.argv.slice(2);
+const isWrite = args.includes("--write");
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`sync-tokens-from-figma.mjs
+
+Uso:
+  FIGMA_PAT=<pat> node scripts/sync-tokens-from-figma.mjs            # dry-run
+  FIGMA_PAT=<pat> node scripts/sync-tokens-from-figma.mjs --write    # aplica
+
+O PAT precisa de permissão file_variables:read. Obtenha em:
+  https://www.figma.com/developers/api#access-tokens`);
+  process.exit(0);
+}
+
+if (!FIGMA_PAT) {
+  console.error("FIGMA_PAT env var requerida. Ver --help.");
+  process.exit(2);
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────────
+
+function fmt(v) {
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function report(diffs, issues) {
+  const total = diffs.VALUE_DRIFT.length + diffs.NEW_IN_FIGMA.length + diffs.MISSING_IN_FIGMA.length;
+  const aliasBroken = issues.filter((i) => i.category === "ALIAS_BROKEN").length;
+
+  console.log("");
+  console.log("═══ sync-tokens-from-figma ═════════════════════════════");
+  console.log(`VALUE_DRIFT      (mesmo nome, valor difere): ${diffs.VALUE_DRIFT.length}`);
+  console.log(`NEW_IN_FIGMA     (Figma tem, JSON não):      ${diffs.NEW_IN_FIGMA.length}`);
+  console.log(`MISSING_IN_FIGMA (JSON tem, Figma não):      ${diffs.MISSING_IN_FIGMA.length}`);
+  console.log(`ALIAS_BROKEN     (Figma aponta pra órfão):   ${aliasBroken}`);
+  console.log("═════════════════════════════════════════════════════════");
+
+  const section = (title, items, format) => {
+    if (!items.length) return;
+    console.log(`\n┌ ${title} `.padEnd(60, "─"));
+    for (const d of items.slice(0, 50)) console.log("  " + format(d));
+    if (items.length > 50) console.log(`  ... +${items.length - 50} mais`);
+  };
+
+  section(
+    "VALUE_DRIFT",
+    diffs.VALUE_DRIFT,
+    (d) => `${d.token}\n    Figma: ${fmt(d.figma)}\n    JSON:  ${fmt(d.json)}`
+  );
+  section(
+    "NEW_IN_FIGMA (requer adição manual)",
+    diffs.NEW_IN_FIGMA,
+    (d) => `${d.token} = ${fmt(d.figma)} → ${d.file}`
+  );
+  section(
+    "MISSING_IN_FIGMA (requer remoção manual ou adição no Figma)",
+    diffs.MISSING_IN_FIGMA,
+    (d) => `${d.token} (valor JSON: ${fmt(d.json)}) ← ${d.file}`
+  );
+  section(
+    "ALIAS_BROKEN",
+    issues.filter((i) => i.category === "ALIAS_BROKEN"),
+    (i) => `${i.token}${i.mode ? ` (${i.mode})` : ""} → alvo: ${i.target}`
+  );
+
+  console.log("");
+  return total;
+}
+
+// ─── Write ──────────────────────────────────────────────────────────────────
+
+function applyValueDrifts(drifts) {
+  const byFile = {};
+  for (const d of drifts) (byFile[d.file] ||= []).push(d);
+
+  for (const [relFile, fixes] of Object.entries(byFile)) {
+    const abs = path.join(TOKENS_DIR, relFile);
+    const json = JSON.parse(fs.readFileSync(abs, "utf8"));
+    for (const fix of fixes) {
+      const parts = fix.token.split(".");
+      let cur = json;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (!cur || !(parts[i] in cur)) {
+          console.warn(`  [skip] ${fix.token}: path ausente em ${relFile}`);
+          cur = null;
+          break;
+        }
+        cur = cur[parts[i]];
+      }
+      if (!cur) continue;
+      const leaf = parts[parts.length - 1];
+      if (!cur[leaf] || typeof cur[leaf] !== "object" || !("$value" in cur[leaf])) {
+        console.warn(`  [skip] ${fix.token}: folha inválida em ${relFile}`);
+        continue;
+      }
+      cur[leaf].$value = fix.figma;
+    }
+    fs.writeFileSync(abs, JSON.stringify(json, null, 2) + "\n");
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("Buscando Figma Variables...");
+  const meta = await fetchFigmaVariables(FIGMA_PAT);
+  console.log(
+    `  ${Object.keys(meta.variables).length} variables em ${Object.keys(meta.variableCollections).length} collections`
+  );
+
+  console.log("Construindo estado esperado...");
+  const { state: expected, issues } = buildExpectedState(meta);
+
+  console.log("Lendo JSONs atuais...");
+  const actual = readCurrentState(TOKENS_DIR);
+
+  console.log("Comparando...");
+  const diffs = compareStates(expected, actual);
+  const total = report(diffs, issues);
+
+  if (!isWrite) {
+    if (total === 0) {
+      console.log("Figma e JSON em dia.");
+      process.exit(0);
+    }
+    console.log(
+      `Dry-run: ${total} divergência(s). Use --write pra aplicar VALUE_DRIFT (${diffs.VALUE_DRIFT.length}).`
+    );
+    process.exit(1);
+  }
+
+  if (diffs.VALUE_DRIFT.length === 0) {
+    console.log("Nada a aplicar (VALUE_DRIFT vazio).");
+    if (diffs.NEW_IN_FIGMA.length || diffs.MISSING_IN_FIGMA.length) {
+      console.log("Há pendências que exigem revisão manual — ver relatório acima.");
+    }
+    process.exit(0);
+  }
+
+  console.log(`Aplicando ${diffs.VALUE_DRIFT.length} VALUE_DRIFT(s)...`);
+  applyValueDrifts(diffs.VALUE_DRIFT);
+
+  for (const step of ["build:tokens", "sync:docs"]) {
+    console.log(`Rodando npm run ${step}...`);
+    const r = spawnSync("npm", ["run", step], { cwd: ROOT, stdio: "inherit" });
+    if (r.status !== 0) {
+      console.error(`${step} falhou.`);
+      process.exit(2);
+    }
+  }
+
+  console.log("");
+  console.log("✅ VALUE_DRIFT aplicados. Revisar git diff antes de commitar.");
+  if (diffs.NEW_IN_FIGMA.length || diffs.MISSING_IN_FIGMA.length) {
+    console.log("⚠ Pendências NEW_IN_FIGMA / MISSING_IN_FIGMA exigem ação manual. Ver relatório.");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/scripts/tokens-verify.mjs
+++ b/scripts/tokens-verify.mjs
@@ -29,13 +29,20 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  FIGMA_FILE_KEY,
+  fetchFigmaVariables,
+  buildExpectedState,
+  readCurrentState,
+  compareStates,
+} from "./lib/figma-dtcg.mjs";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const TOKENS_DIR = path.join(ROOT, "tokens");
 const CSS_DIR = path.join(ROOT, "css", "tokens", "generated");
 const OUT_JSON = path.join(ROOT, "docs", "api", "tokens-sync.json");
 const OUT_HTML = path.join(ROOT, "docs", "tokens-sync.html");
-const FIGMA_FILE_KEY = "PRYS2kL7VdC1MtVWfZvuDN";
 
 // -----------------------------------------------------------------------------
 // utilidades
@@ -245,55 +252,99 @@ function compareJsonToCss({ shared, light, dark, lightAll, darkAll }) {
 // -----------------------------------------------------------------------------
 // 3. Comparar com Figma Variables
 // -----------------------------------------------------------------------------
+//
+// Classificação alinhada com ADR-003 revisada (Figma é autoridade):
+//
+//   NEEDS_SYNC        Figma tem token que JSON não tem. Warning — rodar
+//                     sync:tokens-from-figma. Esperado após designer criar
+//                     uma Variable nova sem ter sincronizado ainda.
+//
+//   DRIFT_FROM_SOURCE JSON tem token que Figma não tem. Erro — indica
+//                     edição manual do JSON (proibida) OU Variable deletada
+//                     no Figma sem sync. Exige intervenção humana.
+//
+//   VALUE_DRIFT       Mesmo nome, valor diferente. Erro — rodar
+//                     sync:tokens-from-figma:write pra alinhar.
 
-async function fetchFigmaVariables(pat) {
-  const url = `https://api.figma.com/v1/files/${FIGMA_FILE_KEY}/variables/local`;
-  const res = await fetch(url, {
-    headers: { "X-Figma-Token": pat },
-  });
-  if (!res.ok) {
-    throw new Error(`Figma API retornou ${res.status}: ${await res.text()}`);
-  }
-  return res.json();
-}
-
-async function compareJsonToFigma(all, pat) {
+async function compareJsonToFigma(pat) {
   if (!pat) {
     return {
       skipped: true,
-      reason: "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat>.",
+      reason:
+        "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat> ou configure o secret no CI.",
       divergences: [],
+      counts: { NEEDS_SYNC: 0, DRIFT_FROM_SOURCE: 0, VALUE_DRIFT: 0, ALIAS_BROKEN: 0 },
     };
   }
-  let figma;
+
+  let meta;
   try {
-    figma = await fetchFigmaVariables(pat);
+    meta = await fetchFigmaVariables(pat);
   } catch (e) {
     return {
       skipped: true,
       reason: `Erro ao consultar Figma: ${e.message}`,
       divergences: [],
+      counts: { NEEDS_SYNC: 0, DRIFT_FROM_SOURCE: 0, VALUE_DRIFT: 0, ALIAS_BROKEN: 0 },
     };
   }
-  // A API retorna meta.variables e meta.variableCollections. Precisamos
-  // mapear variáveis para um formato comparável com os tokens do JSON.
-  // A comparação plena exige resolução de alias entre variáveis Figma,
-  // escolha de modo (Light/Dark), e normalização de formato de cor —
-  // está documentada como TODO abaixo para a próxima iteração.
-  const variables = figma.meta?.variables ?? {};
-  const collections = figma.meta?.variableCollections ?? {};
+
+  const { state: expected, issues } = buildExpectedState(meta);
+  const actual = readCurrentState(TOKENS_DIR);
+  const raw = compareStates(expected, actual);
+  const aliasBroken = issues.filter((i) => i.category === "ALIAS_BROKEN");
+
+  // Traduz categorias internas para o vocabulário do ADR-003
+  const divergences = [
+    ...raw.NEW_IN_FIGMA.map((d) => ({
+      level: "warning",
+      category: "NEEDS_SYNC",
+      token: d.token,
+      file: d.file,
+      figma: d.figma,
+      message: "Figma tem este token mas JSON ainda não — rodar npm run sync:tokens-from-figma:write",
+    })),
+    ...raw.MISSING_IN_FIGMA.map((d) => ({
+      level: "error",
+      category: "DRIFT_FROM_SOURCE",
+      token: d.token,
+      file: d.file,
+      json: d.json,
+      message:
+        "JSON tem token que Figma não tem. Indica edição manual do JSON ou Variable removida no Figma sem sync.",
+    })),
+    ...raw.VALUE_DRIFT.map((d) => ({
+      level: "error",
+      category: "VALUE_DRIFT",
+      token: d.token,
+      file: d.file,
+      figma: d.figma,
+      json: d.json,
+      message: "Valor difere entre Figma (autoridade) e JSON — rodar sync:tokens-from-figma:write",
+    })),
+    ...aliasBroken.map((i) => ({
+      level: "warning",
+      category: "ALIAS_BROKEN",
+      token: i.token,
+      mode: i.mode,
+      target: i.target,
+      message: "Variável Figma aponta pra um alias inexistente.",
+    })),
+  ];
+
   return {
     skipped: false,
     summary: {
-      figmaVariableCount: Object.keys(variables).length,
-      figmaCollectionCount: Object.keys(collections).length,
-      jsonTokenCount: Object.keys(all).length,
+      figmaVariableCount: Object.keys(meta.variables).length,
+      figmaCollectionCount: Object.keys(meta.variableCollections).length,
     },
-    // TODO: comparação nome-por-nome, valor-por-valor, modo-por-modo.
-    // Exige mapeamento das convenções (Figma usa / como separador, DTCG usa .)
-    // e resolução de alias. A primeira iteração apenas confirma conectividade.
-    divergences: [],
-    note: "Comparação detalhada Figma ↔ JSON pendente. Primeira iteração confirma que a API responde e coleta a contagem de variáveis.",
+    divergences,
+    counts: {
+      NEEDS_SYNC: raw.NEW_IN_FIGMA.length,
+      DRIFT_FROM_SOURCE: raw.MISSING_IN_FIGMA.length,
+      VALUE_DRIFT: raw.VALUE_DRIFT.length,
+      ALIAS_BROKEN: aliasBroken.length,
+    },
   };
 }
 
@@ -431,16 +482,21 @@ async function main() {
   const totalTokens = Object.keys(bundle.shared).length + Object.keys(bundle.light).length + Object.keys(bundle.dark).length;
   const jsonIntegrity = checkJsonIntegrity(bundle.lightAll, bundle.darkAll);
   const jsonVsCss = compareJsonToCss(bundle);
-  // Para a verificação Figma usa o pool combinado (light) como representativo.
-  // A comparação específica por modo será implementada junto com a resolução
-  // de alias Figma.
-  const jsonVsFigma = await compareJsonToFigma(bundle.lightAll, process.env.FIGMA_PAT);
+  const jsonVsFigma = await compareJsonToFigma(process.env.FIGMA_PAT);
+
+  // Fase de adaptação (ADR-003 revisada em 0.5.8): DRIFT_FROM_SOURCE e
+  // VALUE_DRIFT ainda contam como WARNING no CI durante duas semanas,
+  // depois passam a ERROR. Por ora, Figma divergences não bloqueiam o
+  // CI — mas aparecem no relatório.
+  const jsonVsFigmaErrors = 0; // (jsonVsFigma.divergences || []).filter((d) => d.level === "error").length;
+  const jsonVsFigmaWarnings = (jsonVsFigma.divergences || []).length;
 
   const errors = jsonIntegrity.filter((d) => d.level === "error").length +
     jsonVsCss.filter((d) => d.level === "error").length +
-    (jsonVsFigma.divergences?.length || 0);
+    jsonVsFigmaErrors;
   const warnings = jsonIntegrity.filter((d) => d.level === "warning").length +
-    jsonVsCss.filter((d) => d.level === "warning").length;
+    jsonVsCss.filter((d) => d.level === "warning").length +
+    jsonVsFigmaWarnings;
 
   const report = {
     generatedAt: new Date().toISOString(),
@@ -468,8 +524,14 @@ async function main() {
   if (jsonVsFigma.skipped) {
     console.log(`JSON ↔ Figma:     SKIP — ${jsonVsFigma.reason}`);
   } else {
-    console.log(`JSON ↔ Figma:     ${jsonVsFigma.divergences.length === 0 ? "OK (smoke)" : `${jsonVsFigma.divergences.length} divergências`}`);
-    if (jsonVsFigma.note) console.log(`                  nota: ${jsonVsFigma.note}`);
+    const c = jsonVsFigma.counts;
+    const total = c.NEEDS_SYNC + c.DRIFT_FROM_SOURCE + c.VALUE_DRIFT + c.ALIAS_BROKEN;
+    if (total === 0) {
+      console.log(`JSON ↔ Figma:     OK (Figma = ${jsonVsFigma.summary.figmaVariableCount} vars, tudo em dia)`);
+    } else {
+      console.log(`JSON ↔ Figma:     ${total} divergências — NEEDS_SYNC=${c.NEEDS_SYNC} DRIFT_FROM_SOURCE=${c.DRIFT_FROM_SOURCE} VALUE_DRIFT=${c.VALUE_DRIFT} ALIAS_BROKEN=${c.ALIAS_BROKEN}`);
+      console.log("                  rodar 'npm run sync:tokens-from-figma' pra detalhes e 'npm run sync:tokens-from-figma:write' pra aplicar VALUE_DRIFT");
+    }
   }
   console.log(`Avisos:           ${warnings}`);
   console.log(`Erros:            ${errors}`);


### PR DESCRIPTION
## Summary

Implementa a decisão da ADR-003 revisada em 0.5.8: **Figma Variables são autoridade, JSONs são consolidação**. Primeira ferramenta no lado Figma → JSON do ciclo.

## Arquivos novos

- `scripts/sync-tokens-from-figma.mjs` — CLI com `--dry-run` e `--write`. Classifica divergências em `VALUE_DRIFT` / `NEW_IN_FIGMA` / `MISSING_IN_FIGMA` / `ALIAS_BROKEN`. Só aplica `VALUE_DRIFT` in-place; criações/remoções exigem ação manual (conservador).
- `scripts/lib/figma-dtcg.mjs` — módulo compartilhado (fetch, conversão, comparador).
- `.github/workflows/sync-tokens-from-figma.yml` — `workflow_dispatch` que roda `--write` e abre PR com diff.

## Alterado

- `scripts/tokens-verify.mjs` reutiliza o mesmo lib e classifica Figma divergences. Fase de adaptação: warnings durante 2 semanas, depois bloqueia CI.
- `package.json`: `sync:tokens-from-figma` e `:write`.
- Normalização de dimensões: `1rem`, `16px`, `16` todos equivalem a `px:16`.

## Test plan

- [ ] `npm run sync:tokens-from-figma` sem PAT: falha gracioso
- [ ] `npm run verify:tokens` sem PAT: passa com skip
- [ ] Com FIGMA_PAT configurado como secret no GitHub, rodar workflow: abre PR com diff se houver divergências
- [ ] Alterar um valor numa Figma Variable, rodar `:write` local → JSON atualiza, CSS regenera
- [ ] Reverter no Figma, rodar `:write` → JSON volta ao estado

## Bump

0.5.8 → 0.6.0 (minor: nova capability de sistema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)