### PR TITLE
feat(tokens): sync Figma → JSON via MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules/
 # macOS
 .DS_Store
 **/.DS_Store
+
+# Figma snapshot gerado via MCP (sync Figma → JSON)
+.figma-snapshot.json
+.figma-snapshot.*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.10]
+
+### Adicionado
+- `scripts/sync-tokens-from-figma.mjs` + `scripts/lib/figma-dtcg.mjs`: sync Figma → JSON baseado em snapshot gerado via MCP. Desvia da limitação da REST API (exclusiva Enterprise) usando o MCP remoto `use_figma` — agente Claude Code dumpa as ~462 Variables em `.figma-snapshot.json` (gitignored), e o script Node compara com `tokens/**/*.json` em 4 categorias: VALUE_DRIFT (auto-corrigível com `--write`), NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.
+- `docs/process-figma-sync.md`: passo-a-passo do fluxo, incluindo troubleshooting e limitações.
+- npm scripts: `sync:tokens-from-figma` (dry-run) e `sync:tokens-from-figma:write`.
+- `.figma-snapshot.json` e variações no `.gitignore` (snapshot é derivado, não vai pro repo).
+
+### Alterado
+- CLAUDE.md: regras de ouro de tokens atualizadas com o fluxo MCP concreto (em vez de "mecanismo em reavaliação"). Ferramentas lista os dois scripts novos.
+- `docs/backlog.md`: item "Implementar o sync Figma → JSON" (que tinha 4 opções em aberto) substituído por "Automatizar o sync Figma → JSON em CI" — reconhece que a opção (b) MCP está implementada pro fluxo manual e mantém as outras 3 (plugin custom, Tokens Studio, Enterprise) como caminhos pra automação futura.
+
+### Notas
+- Direção canônica da ADR-003 continua: Figma é autoridade, JSON é consolidação derivada. O sync consolida essa direção na prática — mas é manual (exige sessão Claude Code), não roda em GitHub Actions.
+- `verify:tokens` não foi alterado nesse PR; continua checando coerência JSON ↔ CSS.
+
 ## [0.5.9]
 
 ### Revertido

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,13 @@ Regras de ouro:
 
 - **Nunca editar `tokens/*.json` à mão.** Alterações devem vir do Figma.
 - **Sempre editar Figma Variables primeiro.** Designer decide, propagação pro JSON acontece depois.
-- O mecanismo de propagação Figma → JSON está em reavaliação (ver `docs/backlog.md` — a API REST de Variables exige plano Enterprise, o que não cabe no plano atual). Por enquanto, quando for necessário alterar tokens, fazer no Figma e abrir issue pedindo sync manual; mudança no JSON via PR só com aprovação (e com menção clara à intenção do design).
+- **Sync Figma → JSON** acontece via MCP + script custom, disparado manualmente numa sessão Claude Code:
+  1. Agente executa `use_figma` em chunks pra dumpar as ~462 Variables em `.figma-snapshot.json` (gitignored).
+  2. `npm run sync:tokens-from-figma` (dry-run) reporta divergências em 4 categorias: VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.
+  3. `npm run sync:tokens-from-figma:write` aplica VALUE_DRIFT nos JSONs e roda `build:tokens` + `sync:docs`.
+  4. Review `git diff`, abrir PR.
+
+  Detalhes passo-a-passo em `docs/process-figma-sync.md`. Automação em CI depende de Enterprise ou plugin custom — ver `docs/backlog.md`.
 
 No CI (`.github/workflows/deploy.yml`), `npm run build:tokens` roda em cada push pra main e auto-commita os arquivos CSS gerados.
 
@@ -127,6 +133,8 @@ npm run verify:tokens                  # Valida coerência Figma ↔ JSON ↔ CS
 npm run build:api                      # Gera docs/api/*.json
 npm run build:llms                     # Gera docs/llms.txt e llms-full.txt
 npm run build:all                      # roda build:tokens → sync:docs → build:api → build:llms → verify:tokens
+npm run sync:tokens-from-figma         # Compara .figma-snapshot.json ↔ tokens/ (dry-run, ver process-figma-sync.md)
+npm run sync:tokens-from-figma:write   # Aplica VALUE_DRIFT e regenera CSS
 ```
 
 ## Quando houver dúvida

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T15:02:34.506Z",
-  "version": "0.6.0",
+  "generatedAt": "2026-04-21T16:25:03.780Z",
+  "version": "0.5.10",
   "count": 11,
   "adrs": [
     {

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T15:02:34.506Z",
-  "version": "0.6.0",
+  "generatedAt": "2026-04-21T16:25:03.780Z",
+  "version": "0.5.10",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T15:02:34.506Z",
-  "version": "0.6.0",
+  "generatedAt": "2026-04-21T16:25:03.780Z",
+  "version": "0.5.10",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T15:02:34.835Z",
+  "generatedAt": "2026-04-21T16:25:04.246Z",
   "totals": {
     "jsonTokens": 632,
     "sharedTokens": 368,
@@ -13,14 +13,8 @@
     "jsonVsCss": [],
     "jsonVsFigma": {
       "skipped": true,
-      "reason": "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat> ou configure o secret no CI.",
-      "divergences": [],
-      "counts": {
-        "NEEDS_SYNC": 0,
-        "DRIFT_FROM_SOURCE": 0,
-        "VALUE_DRIFT": 0,
-        "ALIAS_BROKEN": 0
-      }
+      "reason": "FIGMA_PAT ausente. Para ativar a verificação com Figma, exporte FIGMA_PAT=<seu-pat>.",
+      "divergences": []
     }
   }
 }

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T15:02:34.506Z",
-  "version": "0.6.0",
+  "generatedAt": "2026-04-21T16:25:03.780Z",
+  "version": "0.5.10",
   "counts": {
     "foundation": 231,
     "semanticLight": 132,

--- a/docs/backlog.html
+++ b/docs/backlog.html
@@ -72,14 +72,13 @@
   <div class="ds-md-content">
 <p>Itens fora do escopo imediato mas que devem ser implementados. Organizados por prioridade.</p>
 <h2>Alta prioridade</h2>
-<h3>Implementar o sync Figma → JSON (substitui a tentativa revertida em 0.5.9)</h3>
-<p>Contexto: a ADR-003 foi revisada em 0.5.8 declarando <strong>Figma como autoridade canônica</strong> dos valores de token. Em 0.6.0, o script <code>sync-tokens-from-figma.mjs</code> foi implementado via REST API (<code>GET /v1/files/:key/variables/local</code>), mas <strong>foi revertido em 0.5.9</strong> depois de descobrirmos que a API <code>file_variables:read</code> é <strong>exclusiva do plano Enterprise</strong> (nosso plano atual é Pro/Expert). A decisão arquitetônica da ADR-003 continua válida; o mecanismo técnico de sync precisa de outra abordagem.</p>
-<p>Opções a avaliar:</p>
+<h3>Automatizar o sync Figma → JSON em CI</h3>
+<p>Em 0.5.10 implementamos a opção <strong>(b) adaptar pra MCP</strong> (ver <code>docs/process-figma-sync.md</code>): o agente Claude Code dumpa as Variables em <code>.figma-snapshot.json</code> via <code>use_figma</code> em chunks, e <code>scripts/sync-tokens-from-figma.mjs</code> compara/aplica divergências. Funciona, mas exige sessão interativa — não roda em GitHub Actions.</p>
+<p>Pra automatizar de verdade (disparo por webhook ou agendamento), há 3 caminhos:</p>
 <p><strong>(a) Plugin Figma custom</strong> — rodaria dentro do Figma via Plugin API (que não é plano-gated). Botão &quot;Publicar variables&quot; que serializa em DTCG e faz POST/commit pra GitHub (usando GitHub App ou OAuth). Custo: 1–2 semanas de dev + manutenção própria.</p>
-<p><strong>(b) Adaptar o script revertido pra usar MCP (<code>use_figma</code>)</strong> — o MCP remoto já autenticado (UXIN Pro) consegue ler variables via Plugin API interna, sem depender do plano. A mesma lógica de <code>scripts/lib/figma-dtcg.mjs</code> (revertido em 0.5.9, disponível no git em <code>git show 9d531a8</code>) pode ser reutilizada. Limitação: só roda em sessão interativa de Claude Code; não dá pra automatizar em GitHub Actions. Custo: ~2h.</p>
-<p><strong>(c) Tokens Studio for Figma (plugin de terceiros)</strong> — plugin pago/gratuito (conforme tier) que já faz Figma → JSON + push pra Git via OAuth. Migrar as 620 Variables nativas atuais pra dentro do Tokens Studio exige reconfiguração. Ajusta <code>build-tokens.mjs</code> pro formato que ele exporta. Custo: 2–3 dias + designer precisa aprender o plugin.</p>
-<p><strong>(d) Upgrade para plano Enterprise</strong> — destrava a REST API direta, volta o script original. Decisão de negócio (≈ US$ 75/editor/mês).</p>
-<p>Decisão pendente.</p>
+<p><strong>(b) Tokens Studio for Figma (plugin de terceiros)</strong> — plugin com free tier, que faz Figma → JSON + push pra Git via OAuth. Migrar as 462 Variables nativas atuais pra dentro do Tokens Studio exige reconfiguração. Ajusta <code>build-tokens.mjs</code> pro formato que ele exporta. Custo: 2–3 dias + designer precisa aprender o plugin.</p>
+<p><strong>(c) Upgrade para plano Enterprise</strong> — destrava a REST API direta (<code>GET /v1/files/:key/variables/local</code>), possibilitando o script original revertido em 0.5.9. Decisão de negócio (≈ US$ 75/editor/mês).</p>
+<p>Enquanto o disparo manual não virar gargalo, fica como está. Revisitar quando frequência de sync aumentar ou quando o volume de divergências manuais crescer.</p>
 <h3>Preencher <code>docs/brand-principles.md</code></h3>
 <p>Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.</p>
 <h3>Reduzir documentação textual do Figma</h3>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,21 +4,19 @@ Itens fora do escopo imediato mas que devem ser implementados. Organizados por p
 
 ## Alta prioridade
 
-### Implementar o sync Figma → JSON (substitui a tentativa revertida em 0.5.9)
+### Automatizar o sync Figma → JSON em CI
 
-Contexto: a ADR-003 foi revisada em 0.5.8 declarando **Figma como autoridade canônica** dos valores de token. Em 0.6.0, o script `sync-tokens-from-figma.mjs` foi implementado via REST API (`GET /v1/files/:key/variables/local`), mas **foi revertido em 0.5.9** depois de descobrirmos que a API `file_variables:read` é **exclusiva do plano Enterprise** (nosso plano atual é Pro/Expert). A decisão arquitetônica da ADR-003 continua válida; o mecanismo técnico de sync precisa de outra abordagem.
+Em 0.5.10 implementamos a opção **(b) adaptar pra MCP** (ver `docs/process-figma-sync.md`): o agente Claude Code dumpa as Variables em `.figma-snapshot.json` via `use_figma` em chunks, e `scripts/sync-tokens-from-figma.mjs` compara/aplica divergências. Funciona, mas exige sessão interativa — não roda em GitHub Actions.
 
-Opções a avaliar:
+Pra automatizar de verdade (disparo por webhook ou agendamento), há 3 caminhos:
 
 **(a) Plugin Figma custom** — rodaria dentro do Figma via Plugin API (que não é plano-gated). Botão "Publicar variables" que serializa em DTCG e faz POST/commit pra GitHub (usando GitHub App ou OAuth). Custo: 1–2 semanas de dev + manutenção própria.
 
-**(b) Adaptar o script revertido pra usar MCP (`use_figma`)** — o MCP remoto já autenticado (UXIN Pro) consegue ler variables via Plugin API interna, sem depender do plano. A mesma lógica de `scripts/lib/figma-dtcg.mjs` (revertido em 0.5.9, disponível no git em `git show 9d531a8`) pode ser reutilizada. Limitação: só roda em sessão interativa de Claude Code; não dá pra automatizar em GitHub Actions. Custo: ~2h.
+**(b) Tokens Studio for Figma (plugin de terceiros)** — plugin com free tier, que faz Figma → JSON + push pra Git via OAuth. Migrar as 462 Variables nativas atuais pra dentro do Tokens Studio exige reconfiguração. Ajusta `build-tokens.mjs` pro formato que ele exporta. Custo: 2–3 dias + designer precisa aprender o plugin.
 
-**(c) Tokens Studio for Figma (plugin de terceiros)** — plugin pago/gratuito (conforme tier) que já faz Figma → JSON + push pra Git via OAuth. Migrar as 620 Variables nativas atuais pra dentro do Tokens Studio exige reconfiguração. Ajusta `build-tokens.mjs` pro formato que ele exporta. Custo: 2–3 dias + designer precisa aprender o plugin.
+**(c) Upgrade para plano Enterprise** — destrava a REST API direta (`GET /v1/files/:key/variables/local`), possibilitando o script original revertido em 0.5.9. Decisão de negócio (≈ US$ 75/editor/mês).
 
-**(d) Upgrade para plano Enterprise** — destrava a REST API direta, volta o script original. Decisão de negócio (≈ US$ 75/editor/mês).
-
-Decisão pendente.
+Enquanto o disparo manual não virar gargalo, fica como está. Revisitar quando frequência de sync aumentar ou quando o volume de divergências manuais crescer.
 
 ### Preencher `docs/brand-principles.md`
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,24 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.10]</h2>
+<h3>Adicionado</h3>
+<ul>
+<li><code>scripts/sync-tokens-from-figma.mjs</code> + <code>scripts/lib/figma-dtcg.mjs</code>: sync Figma → JSON baseado em snapshot gerado via MCP. Desvia da limitação da REST API (exclusiva Enterprise) usando o MCP remoto <code>use_figma</code> — agente Claude Code dumpa as ~462 Variables em <code>.figma-snapshot.json</code> (gitignored), e o script Node compara com <code>tokens/**/*.json</code> em 4 categorias: VALUE_DRIFT (auto-corrigível com <code>--write</code>), NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.</li>
+<li><code>docs/process-figma-sync.md</code>: passo-a-passo do fluxo, incluindo troubleshooting e limitações.</li>
+<li>npm scripts: <code>sync:tokens-from-figma</code> (dry-run) e <code>sync:tokens-from-figma:write</code>.</li>
+<li><code>.figma-snapshot.json</code> e variações no <code>.gitignore</code> (snapshot é derivado, não vai pro repo).</li>
+</ul>
+<h3>Alterado</h3>
+<ul>
+<li>CLAUDE.md: regras de ouro de tokens atualizadas com o fluxo MCP concreto (em vez de &quot;mecanismo em reavaliação&quot;). Ferramentas lista os dois scripts novos.</li>
+<li><code>docs/backlog.md</code>: item &quot;Implementar o sync Figma → JSON&quot; (que tinha 4 opções em aberto) substituído por &quot;Automatizar o sync Figma → JSON em CI&quot; — reconhece que a opção (b) MCP está implementada pro fluxo manual e mantém as outras 3 (plugin custom, Tokens Studio, Enterprise) como caminhos pra automação futura.</li>
+</ul>
+<h3>Notas</h3>
+<ul>
+<li>Direção canônica da ADR-003 continua: Figma é autoridade, JSON é consolidação derivada. O sync consolida essa direção na prática — mas é manual (exige sessão Claude Code), não roda em GitHub Actions.</li>
+<li><code>verify:tokens</code> não foi alterado nesse PR; continua checando coerência JSON ↔ CSS.</li>
+</ul>
 <h2>[0.5.9]</h2>
 <h3>Revertido</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.9**
+> Versão atual: **0.5.10**
 
 ## Status geral
 

--- a/docs/decisions/ADR-003-fontes-verdade.md
+++ b/docs/decisions/ADR-003-fontes-verdade.md
@@ -77,7 +77,7 @@ O workflow `.github/workflows/verify-tokens.yml` roda em pull requests e push pr
 
 **Manter Git como source (ADR-003 original, pré-revisão).** Descartada porque separa a decisão (Figma) da representação canônica (JSON), forçando sincronização em ordem não natural.
 
-**Tokens Studio como intermediário no Figma.** Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 620 Variables do formato nativo pra dentro do plugin, ajustar `build-tokens.mjs` pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).
+**Tokens Studio como intermediário no Figma.** Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 462 Variables do formato nativo pra dentro do plugin, ajustar `build-tokens.mjs` pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).
 
 **Plugin Figma custom.** Descartada por ROI. Desenvolvimento + manutenção maior que o script via MCP pra o mesmo resultado funcional no cenário atual.
 

--- a/docs/decisions/adr-003-fontes-verdade.html
+++ b/docs/decisions/adr-003-fontes-verdade.html
@@ -134,7 +134,7 @@ site em docs/ + Storybook (futuro)
 </ul>
 <h2>Alternativas consideradas</h2>
 <p><strong>Manter Git como source (ADR-003 original, pré-revisão).</strong> Descartada porque separa a decisão (Figma) da representação canônica (JSON), forçando sincronização em ordem não natural.</p>
-<p><strong>Tokens Studio como intermediário no Figma.</strong> Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 620 Variables do formato nativo pra dentro do plugin, ajustar <code>build-tokens.mjs</code> pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).</p>
+<p><strong>Tokens Studio como intermediário no Figma.</strong> Avaliada e descartada pra este momento. Tokens Studio exigiria migrar 462 Variables do formato nativo pra dentro do plugin, ajustar <code>build-tokens.mjs</code> pro formato exportado por ele, e requer que designers aprendam UI nova. Sem ganho proporcional ao custo na nossa escala atual. Reavaliar quando houver time de design maior e necessidade explícita das features do Tokens Studio (branches em tokens, temas via plugin, etc.).</p>
 <p><strong>Plugin Figma custom.</strong> Descartada por ROI. Desenvolvimento + manutenção maior que o script via MCP pra o mesmo resultado funcional no cenário atual.</p>
 <p><strong>Bidirecional automático (webhook Figma).</strong> Descartada pra início. Manual garante controle e revisão. Se o fluxo manual virar gargalo, reavaliar.</p>
 <h2>Referências</h2>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.6.0. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.5.10. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -250,7 +250,7 @@ Direção canônica (ADR-003 revisada em 0.5.8): **Figma Variables são a fonte 
 ```
 Figma Variables              (autoridade — designer é o autor)
       │
-      │ npm run sync:tokens-from-figma  (manual; abre PR com diff)
+      │ sync Figma → JSON    (em desenvolvimento — ver backlog)
       ▼
 tokens/**/*.json             (DTCG — consolidação canônica em Git)
       │
@@ -268,23 +268,29 @@ docs/*.html                  (documentação e preview)
 
 Regras de ouro:
 
-- **Nunca editar `tokens/*.json` à mão.** Alterações vêm do Figma via `sync:tokens-from-figma`.
-- **Sempre editar Figma Variables primeiro.** Designer decide, depois o sync propaga.
-- Exceção: PRs gerados pelo próprio script de sync editam os JSONs — é esperado, revisar o diff antes de mergar.
+- **Nunca editar `tokens/*.json` à mão.** Alterações devem vir do Figma.
+- **Sempre editar Figma Variables primeiro.** Designer decide, propagação pro JSON acontece depois.
+- **Sync Figma → JSON** acontece via MCP + script custom, disparado manualmente numa sessão Claude Code:
+  1. Agente executa `use_figma` em chunks pra dumpar as ~462 Variables em `.figma-snapshot.json` (gitignored).
+  2. `npm run sync:tokens-from-figma` (dry-run) reporta divergências em 4 categorias: VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.
+  3. `npm run sync:tokens-from-figma:write` aplica VALUE_DRIFT nos JSONs e roda `build:tokens` + `sync:docs`.
+  4. Review `git diff`, abrir PR.
 
-No CI (`.github/workflows/deploy.yml`), `npm run build:tokens` roda em cada push pra main e auto-commita os arquivos CSS gerados. O sync Figma→JSON fica em `.github/workflows/sync-tokens-from-figma.yml`, disparado manualmente via `workflow_dispatch`.
+  Detalhes passo-a-passo em `docs/process-figma-sync.md`. Automação em CI depende de Enterprise ou plugin custom — ver `docs/backlog.md`.
+
+No CI (`.github/workflows/deploy.yml`), `npm run build:tokens` roda em cada push pra main e auto-commita os arquivos CSS gerados.
 
 ## Ferramentas disponíveis no repo
 
 ```bash
-npm run sync:tokens-from-figma         # dry-run: lê Figma Variables e mostra diff vs tokens/*.json
-npm run sync:tokens-from-figma:write   # aplica o diff, regenera CSS, pronto pra commitar
 npm run build:tokens                   # Foundation/Semantic/Component → CSS gerado
 npm run sync:docs                      # Regenera inventários em docs/*.md
-npm run verify:tokens                  # Classifica divergências Figma ↔ JSON (NEEDS_SYNC/DRIFT/VALUE)
+npm run verify:tokens                  # Valida coerência Figma ↔ JSON ↔ CSS (Figma check depende de FIGMA_PAT)
 npm run build:api                      # Gera docs/api/*.json
 npm run build:llms                     # Gera docs/llms.txt e llms-full.txt
 npm run build:all                      # roda build:tokens → sync:docs → build:api → build:llms → verify:tokens
+npm run sync:tokens-from-figma         # Compara .figma-snapshot.json ↔ tokens/ (dry-run, ver process-figma-sync.md)
+npm run sync:tokens-from-figma:write   # Aplica VALUE_DRIFT e regenera CSS
 ```
 
 ## Quando houver dúvida
@@ -306,16 +312,35 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
-## [0.6.0]
+## [0.5.10]
 
 ### Adicionado
-- **`scripts/sync-tokens-from-figma.mjs`** — canal oficial Figma → JSON, alinhado à ADR-003 revisada (Figma como autoridade). Dry-run por padrão, `--write` aplica. Apenas `VALUE_DRIFT` é aplicado automaticamente; `NEW_IN_FIGMA` e `MISSING_IN_FIGMA` exigem ação manual (prevenção de criação/remoção não-intencional).
-- **`scripts/lib/figma-dtcg.mjs`** — módulo compartilhado com lógica de fetch Figma, conversão Figma→DTCG e comparação. Reutilizado por `sync-tokens-from-figma.mjs` e `tokens-verify.mjs`.
-- **`.github/workflows/sync-tokens-from-figma.yml`** — workflow manual (`workflow_dispatch`). Suporta dry-run opcional via input. Em modo write, abre PR automático com o diff no corpo. Exige secret `FIGMA_PAT`.
-- Novos npm scripts: `sync:tokens-from-figma` (dry-run) e `sync:tokens-from-figma:write` (aplica).
+- `scripts/sync-tokens-from-figma.mjs` + `scripts/lib/figma-dtcg.mjs`: sync Figma → JSON baseado em snapshot gerado via MCP. Desvia da limitação da REST API (exclusiva Enterprise) usando o MCP remoto `use_figma` — agente Claude Code dumpa as ~462 Variables em `.figma-snapshot.json` (gitignored), e o script Node compara com `tokens/**/*.json` em 4 categorias: VALUE_DRIFT (auto-corrigível com `--write`), NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.
+- `docs/process-figma-sync.md`: passo-a-passo do fluxo, incluindo troubleshooting e limitações.
+- npm scripts: `sync:tokens-from-figma` (dry-run) e `sync:tokens-from-figma:write`.
+- `.figma-snapshot.json` e variações no `.gitignore` (snapshot é derivado, não vai pro repo).
 
 ### Alterado
-- **`scripts/tokens-verify.mjs`** — comparação Figma↔JSON passa da categorização genérica anterior para as três categorias do ADR-003 revisada: `NEEDS_SYNC` (warning), `DRIFT_FROM_SOURCE` (erro) e `VALUE_DRIFT` (erro). Resolução completa de aliases Figma, normalização de dimensões (px/rem equivalentes), suporte a modos Light/Dark separados. Na fase de adaptação (14 dias), todas as categorias ficam como warning — depois `DRIFT_FROM_SOURCE` e `VALUE_DRIFT` passam a falhar o CI.
+- CLAUDE.md: regras de ouro de tokens atualizadas com o fluxo MCP concreto (em vez de "mecanismo em reavaliação"). Ferramentas lista os dois scripts novos.
+- `docs/backlog.md`: item "Implementar o sync Figma → JSON" (que tinha 4 opções em aberto) substituído por "Automatizar o sync Figma → JSON em CI" — reconhece que a opção (b) MCP está implementada pro fluxo manual e mantém as outras 3 (plugin custom, Tokens Studio, Enterprise) como caminhos pra automação futura.
+
+### Notas
+- Direção canônica da ADR-003 continua: Figma é autoridade, JSON é consolidação derivada. O sync consolida essa direção na prática — mas é manual (exige sessão Claude Code), não roda em GitHub Actions.
+- `verify:tokens` não foi alterado nesse PR; continua checando coerência JSON ↔ CSS.
+
+## [0.5.9]
+
+### Revertido
+- Revertido o PR #15 (0.6.0, `feat(tokens): sync Figma → JSON via script + workflow + verify refinado`). Motivo: o endpoint `GET /v1/files/:key/variables/local` da Figma REST API requer o scope `file_variables:read`, que **é exclusivo do plano Enterprise**. Nosso plano atual é Pro/Expert — o PAT não consegue emitir esse scope. Script inútil no plano atual.
+- Removidos: `scripts/sync-tokens-from-figma.mjs`, `scripts/lib/figma-dtcg.mjs`, `.github/workflows/sync-tokens-from-figma.yml`, e os npm scripts correspondentes.
+- `scripts/tokens-verify.mjs` voltou à implementação pré-0.6.0 (sem a classificação NEEDS_SYNC/DRIFT_FROM_SOURCE/VALUE_DRIFT — que dependia do módulo `lib/figma-dtcg.mjs` também revertido).
+
+### Alterado
+- CLAUDE.md: ajustado para refletir que o mecanismo de propagação Figma → JSON está em reavaliação. Regra de ouro "não editar `tokens/*.json` à mão" continua valendo.
+- `docs/backlog.md`: item "Implementar o sync Figma → JSON" adicionado em alta prioridade, listando as quatro opções em aberto (plugin custom, adaptar pra MCP, Tokens Studio, upgrade Enterprise).
+
+### Mantido
+- ADR-003 revisada (Figma como autoridade canônica) continua válida — a decisão conceitual não depende do mecanismo técnico. Só o "como" ficou em aberto.
 
 ## [0.5.8]
 
@@ -507,6 +532,20 @@ Itens fora do escopo imediato mas que devem ser implementados. Organizados por p
 
 ## Alta prioridade
 
+### Automatizar o sync Figma → JSON em CI
+
+Em 0.5.10 implementamos a opção **(b) adaptar pra MCP** (ver `docs/process-figma-sync.md`): o agente Claude Code dumpa as Variables em `.figma-snapshot.json` via `use_figma` em chunks, e `scripts/sync-tokens-from-figma.mjs` compara/aplica divergências. Funciona, mas exige sessão interativa — não roda em GitHub Actions.
+
+Pra automatizar de verdade (disparo por webhook ou agendamento), há 3 caminhos:
+
+**(a) Plugin Figma custom** — rodaria dentro do Figma via Plugin API (que não é plano-gated). Botão "Publicar variables" que serializa em DTCG e faz POST/commit pra GitHub (usando GitHub App ou OAuth). Custo: 1–2 semanas de dev + manutenção própria.
+
+**(b) Tokens Studio for Figma (plugin de terceiros)** — plugin com free tier, que faz Figma → JSON + push pra Git via OAuth. Migrar as 462 Variables nativas atuais pra dentro do Tokens Studio exige reconfiguração. Ajusta `build-tokens.mjs` pro formato que ele exporta. Custo: 2–3 dias + designer precisa aprender o plugin.
+
+**(c) Upgrade para plano Enterprise** — destrava a REST API direta (`GET /v1/files/:key/variables/local`), possibilitando o script original revertido em 0.5.9. Decisão de negócio (≈ US$ 75/editor/mês).
+
+Enquanto o disparo manual não virar gargalo, fica como está. Revisitar quando frequência de sync aumentar ou quando o volume de divergências manuais crescer.
+
 ### Preencher `docs/brand-principles.md`
 
 Template existe, conteúdo real ainda não foi definido. Passa por: missão, 3 princípios de design, tom de voz, identidade visual, logo.
@@ -666,7 +705,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.6.0**
+> Versão atual: **0.5.10**
 
 ## Status geral
 
@@ -821,6 +860,132 @@ Template em `docs/decisions/` (ver ADRs existentes como referência).
 Não edite os arquivos em `css/tokens/generated/` à mão. O CI regenera em cada push pra `main`.
 
 Detalhe completo: [token-architecture.html](./token-architecture.html) e [ADR-001](./decisions/ADR-001-migracao-tokens.md).
+
+
+═══════════════════════════════════════════════════════════
+# docs/process-figma-sync.md
+═══════════════════════════════════════════════════════════
+
+# Processo: sync Figma → JSON via MCP
+
+Como executar o sync das Figma Variables pros arquivos DTCG em `tokens/` usando o MCP remoto do Figma dentro de uma sessão Claude Code.
+
+## Contexto
+
+A ADR-003 (revisada em 0.5.8) estabelece **Figma como autoridade canônica** dos valores de token. Os JSONs em `tokens/` são consolidação derivada. Idealmente existiria um sync automático via REST API, mas `GET /v1/files/:key/variables/local` exige **plano Enterprise** (nosso plano Pro não destrava). Até termos Enterprise (ou implementarmos um plugin custom), o fluxo é manual via MCP: um agente Claude Code executa um script Plugin API que serializa as Variables num JSON temporário, e o script Node `scripts/sync-tokens-from-figma.mjs` lê esse snapshot e compara com os JSONs.
+
+**Disparo:** manual, numa sessão Claude Code com o MCP `use_figma` autenticado no workspace UXIN (Pro). Ver alternativas futuras em `docs/backlog.md` ("Implementar o sync Figma → JSON").
+
+## Pré-requisitos
+
+- Sessão Claude Code com o plugin `figma` (skill `figma:figma-use`) carregado.
+- Workspace UXIN autenticado no MCP do Figma (Pro/Expert basta; não precisa Enterprise).
+- Acesso de leitura ao arquivo `PRYS2kL7VdC1MtVWfZvuDN`.
+
+## Passo 1 — gerar o snapshot via MCP
+
+Peça ao agente Claude Code:
+
+> "Gere um snapshot das Figma Variables do design system em `.figma-snapshot.json`."
+
+O agente vai executar uma sequência de chamadas `use_figma` que:
+
+1. Lista as 4 collections (Foundation, Semantic, Brand, Component) com seus modos.
+2. Itera sobre os ~462 variable IDs em batches de ~50–60 (o MCP tem limite de ~20KB por resposta, então precisa chunkar).
+3. Para cada variável, captura `id`, `name`, `resolvedType`, `variableCollectionId`, `valuesByMode` e `description`.
+4. Agrega tudo num único arquivo `.figma-snapshot.json` no formato:
+
+```json
+{
+  "generatedAt": "2026-04-20T00:00:00.000Z",
+  "fileKey": "PRYS2kL7VdC1MtVWfZvuDN",
+  "variableCollections": {
+    "VariableCollectionId:4:2": { "id": "...", "name": "Foundation", "modes": [...], "defaultModeId": "..." },
+    ...
+  },
+  "variables": {
+    "VariableID:5:3": {
+      "id": "VariableID:5:3",
+      "name": "color/neutral/50",
+      "resolvedType": "COLOR",
+      "variableCollectionId": "VariableCollectionId:4:2",
+      "valuesByMode": { "4:0": { "r": 0.97, "g": 0.98, "b": 0.99, "a": 1 } }
+    },
+    ...
+  }
+}
+```
+
+O arquivo está em `.gitignore` e não deve ser commitado — é regenerado a cada sync.
+
+## Passo 2 — dry-run
+
+```bash
+node scripts/sync-tokens-from-figma.mjs
+```
+
+O script:
+
+1. Lê `.figma-snapshot.json` (ou `--snapshot <path>` pra outro caminho).
+2. Constrói o estado esperado dos JSONs (`tokens/foundation/`, `tokens/semantic/`, `tokens/component/`) a partir das Variables.
+3. Lê os JSONs atuais e compara.
+4. Reporta em 4 categorias:
+
+| Categoria | Significado | Ação em `--write` |
+|-----------|-------------|-------------------|
+| **VALUE_DRIFT** | Mesmo token, valor difere. | Aplica valor do Figma no JSON. |
+| **NEW_IN_FIGMA** | Figma tem, JSON não. | Não cria — revisão manual. |
+| **MISSING_IN_FIGMA** | JSON tem, Figma não. | Não deleta — revisão manual. |
+| **ALIAS_BROKEN** | Figma aponta pra variável inexistente. | Não resolve — fix no Figma. |
+
+Se tudo zerar, Figma e JSON estão em dia. Exit 0.
+
+Se tem divergências, exit 1. Review no output antes de aplicar.
+
+## Passo 3 — aplicar VALUE_DRIFT
+
+Quando os drifts representarem mudanças intencionais feitas no Figma:
+
+```bash
+node scripts/sync-tokens-from-figma.mjs --write
+```
+
+Esse modo:
+
+1. Aplica os VALUE_DRIFT sobrescrevendo `$value` nos arquivos `tokens/**/*.json` correspondentes.
+2. Roda `npm run build:tokens` pra regenerar `css/tokens/generated/*.css`.
+3. Roda `npm run sync:docs` pra atualizar docs.
+4. NEW_IN_FIGMA e MISSING_IN_FIGMA continuam reportados — requer ação manual.
+
+Review `git diff` antes de commitar. Toda mudança de token entra numa PR separada pra auditoria.
+
+## Passo 4 — commit
+
+```bash
+git add tokens/ css/tokens/generated/ docs/api/ docs/tokens-*.html
+git commit -m "sync: tokens do Figma"
+```
+
+Não commitar `.figma-snapshot.json` (está ignorado).
+
+## Troubleshooting
+
+**`Snapshot não encontrado`**: rode o Passo 1 antes.
+
+**`Snapshot inválido: faltam variables/variableCollections`**: o arquivo JSON não tem a estrutura esperada. Re-gerar no Passo 1.
+
+**ALIAS_BROKEN > 0**: alguém apagou uma variável no Figma sem atualizar os aliases. Fix no Figma e re-gerar snapshot.
+
+**Muitos NEW_IN_FIGMA / MISSING_IN_FIGMA**: possível desalinhamento do mapeamento prefix→file em `scripts/lib/figma-dtcg.mjs` (`FOUNDATION_PREFIX_TO_FILE`). Confirme que Figma e JSON usam as mesmas convenções de nome; ajuste o mapa se necessário.
+
+**Ruído de ponto flutuante** (`0.05` vs `0.05000000074505806`): a função `normalizeForCompare` arredonda pra 4 casas. Se ainda aparecer como VALUE_DRIFT, o valor realmente mudou.
+
+## Limitações
+
+- **Manual.** Não roda em CI sem Enterprise ou plugin custom. Ver `docs/backlog.md` pras alternativas.
+- **Não gera commits automáticos.** O usuário decide o que entra em `--write` e quando.
+- **Não cria nem deleta tokens** em JSON. NEW_IN_FIGMA e MISSING_IN_FIGMA exigem edição explícita pra evitar divergências acidentais.
+- **Sem resolução inteligente de rename.** Se um token for renomeado no Figma, aparece como MISSING + NEW — o operador precisa identificar e tratar manualmente.
 
 
 ═══════════════════════════════════════════════════════════
@@ -1152,13 +1317,13 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.6.0**
+> Versão atual: **0.5.10**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.6.0 |
+| Versão | 0.5.10 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -2592,6 +2757,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T15:02:34.668Z
-Versão: 0.6.0
+Gerado por scripts/build-llms.mjs em 2026-04-21T16:25:04.015Z
+Versão: 0.5.10
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.6.0. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.10. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -89,4 +89,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T15:02:34.668Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T16:25:04.015Z.

--- a/docs/process-figma-sync.md
+++ b/docs/process-figma-sync.md
@@ -1,0 +1,120 @@
+# Processo: sync Figma → JSON via MCP
+
+Como executar o sync das Figma Variables pros arquivos DTCG em `tokens/` usando o MCP remoto do Figma dentro de uma sessão Claude Code.
+
+## Contexto
+
+A ADR-003 (revisada em 0.5.8) estabelece **Figma como autoridade canônica** dos valores de token. Os JSONs em `tokens/` são consolidação derivada. Idealmente existiria um sync automático via REST API, mas `GET /v1/files/:key/variables/local` exige **plano Enterprise** (nosso plano Pro não destrava). Até termos Enterprise (ou implementarmos um plugin custom), o fluxo é manual via MCP: um agente Claude Code executa um script Plugin API que serializa as Variables num JSON temporário, e o script Node `scripts/sync-tokens-from-figma.mjs` lê esse snapshot e compara com os JSONs.
+
+**Disparo:** manual, numa sessão Claude Code com o MCP `use_figma` autenticado no workspace UXIN (Pro). Ver alternativas futuras em `docs/backlog.md` ("Implementar o sync Figma → JSON").
+
+## Pré-requisitos
+
+- Sessão Claude Code com o plugin `figma` (skill `figma:figma-use`) carregado.
+- Workspace UXIN autenticado no MCP do Figma (Pro/Expert basta; não precisa Enterprise).
+- Acesso de leitura ao arquivo `PRYS2kL7VdC1MtVWfZvuDN`.
+
+## Passo 1 — gerar o snapshot via MCP
+
+Peça ao agente Claude Code:
+
+> "Gere um snapshot das Figma Variables do design system em `.figma-snapshot.json`."
+
+O agente vai executar uma sequência de chamadas `use_figma` que:
+
+1. Lista as 4 collections (Foundation, Semantic, Brand, Component) com seus modos.
+2. Itera sobre os ~462 variable IDs em batches de ~50–60 (o MCP tem limite de ~20KB por resposta, então precisa chunkar).
+3. Para cada variável, captura `id`, `name`, `resolvedType`, `variableCollectionId`, `valuesByMode` e `description`.
+4. Agrega tudo num único arquivo `.figma-snapshot.json` no formato:
+
+```json
+{
+  "generatedAt": "2026-04-20T00:00:00.000Z",
+  "fileKey": "PRYS2kL7VdC1MtVWfZvuDN",
+  "variableCollections": {
+    "VariableCollectionId:4:2": { "id": "...", "name": "Foundation", "modes": [...], "defaultModeId": "..." },
+    ...
+  },
+  "variables": {
+    "VariableID:5:3": {
+      "id": "VariableID:5:3",
+      "name": "color/neutral/50",
+      "resolvedType": "COLOR",
+      "variableCollectionId": "VariableCollectionId:4:2",
+      "valuesByMode": { "4:0": { "r": 0.97, "g": 0.98, "b": 0.99, "a": 1 } }
+    },
+    ...
+  }
+}
+```
+
+O arquivo está em `.gitignore` e não deve ser commitado — é regenerado a cada sync.
+
+## Passo 2 — dry-run
+
+```bash
+node scripts/sync-tokens-from-figma.mjs
+```
+
+O script:
+
+1. Lê `.figma-snapshot.json` (ou `--snapshot <path>` pra outro caminho).
+2. Constrói o estado esperado dos JSONs (`tokens/foundation/`, `tokens/semantic/`, `tokens/component/`) a partir das Variables.
+3. Lê os JSONs atuais e compara.
+4. Reporta em 4 categorias:
+
+| Categoria | Significado | Ação em `--write` |
+|-----------|-------------|-------------------|
+| **VALUE_DRIFT** | Mesmo token, valor difere. | Aplica valor do Figma no JSON. |
+| **NEW_IN_FIGMA** | Figma tem, JSON não. | Não cria — revisão manual. |
+| **MISSING_IN_FIGMA** | JSON tem, Figma não. | Não deleta — revisão manual. |
+| **ALIAS_BROKEN** | Figma aponta pra variável inexistente. | Não resolve — fix no Figma. |
+
+Se tudo zerar, Figma e JSON estão em dia. Exit 0.
+
+Se tem divergências, exit 1. Review no output antes de aplicar.
+
+## Passo 3 — aplicar VALUE_DRIFT
+
+Quando os drifts representarem mudanças intencionais feitas no Figma:
+
+```bash
+node scripts/sync-tokens-from-figma.mjs --write
+```
+
+Esse modo:
+
+1. Aplica os VALUE_DRIFT sobrescrevendo `$value` nos arquivos `tokens/**/*.json` correspondentes.
+2. Roda `npm run build:tokens` pra regenerar `css/tokens/generated/*.css`.
+3. Roda `npm run sync:docs` pra atualizar docs.
+4. NEW_IN_FIGMA e MISSING_IN_FIGMA continuam reportados — requer ação manual.
+
+Review `git diff` antes de commitar. Toda mudança de token entra numa PR separada pra auditoria.
+
+## Passo 4 — commit
+
+```bash
+git add tokens/ css/tokens/generated/ docs/api/ docs/tokens-*.html
+git commit -m "sync: tokens do Figma"
+```
+
+Não commitar `.figma-snapshot.json` (está ignorado).
+
+## Troubleshooting
+
+**`Snapshot não encontrado`**: rode o Passo 1 antes.
+
+**`Snapshot inválido: faltam variables/variableCollections`**: o arquivo JSON não tem a estrutura esperada. Re-gerar no Passo 1.
+
+**ALIAS_BROKEN > 0**: alguém apagou uma variável no Figma sem atualizar os aliases. Fix no Figma e re-gerar snapshot.
+
+**Muitos NEW_IN_FIGMA / MISSING_IN_FIGMA**: possível desalinhamento do mapeamento prefix→file em `scripts/lib/figma-dtcg.mjs` (`FOUNDATION_PREFIX_TO_FILE`). Confirme que Figma e JSON usam as mesmas convenções de nome; ajuste o mapa se necessário.
+
+**Ruído de ponto flutuante** (`0.05` vs `0.05000000074505806`): a função `normalizeForCompare` arredonda pra 4 casas. Se ainda aparecer como VALUE_DRIFT, o valor realmente mudou.
+
+## Limitações
+
+- **Manual.** Não roda em CI sem Enterprise ou plugin custom. Ver `docs/backlog.md` pras alternativas.
+- **Não gera commits automáticos.** O usuário decide o que entra em `--write` e quando.
+- **Não cria nem deleta tokens** em JSON. NEW_IN_FIGMA e MISSING_IN_FIGMA exigem edição explícita pra evitar divergências acidentais.
+- **Sem resolução inteligente de rename.** Se um token for renomeado no Figma, aparece como MISSING + NEW — o operador precisa identificar e tratar manualmente.

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.9**
+> Versão atual: **0.5.10**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.9 |
+| Versão | 0.5.10 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,7 +63,7 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T15:02:34.835Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T16:25:04.246Z</div>
       <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.9 -->v0.5.9</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.10 -->v0.5.10</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",
@@ -26,7 +26,9 @@
     "verify:tokens": "node scripts/tokens-verify.mjs",
     "build:api": "node scripts/build-api.mjs",
     "build:llms": "node scripts/build-llms.mjs",
-    "build:all": "npm run build:tokens && npm run sync:docs && npm run build:api && npm run build:llms && npm run verify:tokens"
+    "build:all": "npm run build:tokens && npm run sync:docs && npm run build:api && npm run build:llms && npm run verify:tokens",
+    "sync:tokens-from-figma": "node scripts/sync-tokens-from-figma.mjs",
+    "sync:tokens-from-figma:write": "node scripts/sync-tokens-from-figma.mjs --write"
   },
   "devDependencies": {
     "@tokens-studio/sd-transforms": "^2.0.3",

--- a/scripts/lib/figma-dtcg.mjs
+++ b/scripts/lib/figma-dtcg.mjs
@@ -1,0 +1,334 @@
+/**
+ * figma-dtcg.mjs — funções compartilhadas para ler Figma Variables e
+ * convertê-las no formato DTCG do repo. Usado por:
+ *   - scripts/sync-tokens-from-figma.mjs (sync Figma → JSON com --write)
+ *   - scripts/tokens-verify.mjs (verificação de coerência no CI)
+ *
+ * Direção canônica conforme ADR-003 revisada: Figma Variables são a
+ * autoridade. JSONs em tokens/ são consolidação derivada.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const FIGMA_FILE_KEY = "PRYS2kL7VdC1MtVWfZvuDN";
+
+// Prefixo do nome da variável Figma → arquivo em tokens/foundation/
+export const FOUNDATION_PREFIX_TO_FILE = {
+  color: "colors.json",
+  font: "typography.json",
+  spacing: "spacing.json",
+  radius: "radius.json",
+  opacity: "opacity.json",
+  border: "stroke.json",
+};
+
+// Brand tem 3 modos (Default/Ocean/Forest), só Default entra em foundation/brand.json.
+export const BRAND_MODE = "Default";
+// Component tem 1 modo "Default".
+export const COMPONENT_MODE = "Default";
+
+// ─── Obter o snapshot do Figma ───────────────────────────────────────────────
+//
+// A API REST GET /v1/files/:key/variables/local exige plano Enterprise do
+// Figma. No plano Pro (nosso caso), usamos o MCP remoto (`use_figma`) via
+// Claude Code: o agente executa um script Plugin API que dumpa as Variables
+// num JSON temporário, e este módulo lê esse arquivo.
+//
+// Formato esperado:
+//   { variables: {...}, variableCollections: {...} }
+//
+// Gerar via MCP: ver docs/process-figma-sync.md.
+
+export function readFigmaSnapshot(snapshotPath) {
+  if (!fs.existsSync(snapshotPath)) {
+    throw new Error(
+      `Snapshot não encontrado em ${snapshotPath}. Gerar via Claude Code com use_figma (ver docs/process-figma-sync.md).`
+    );
+  }
+  const raw = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+  if (!raw.variables || !raw.variableCollections) {
+    throw new Error(`Snapshot inválido: faltam variables/variableCollections em ${snapshotPath}.`);
+  }
+  return { variables: raw.variables, variableCollections: raw.variableCollections };
+}
+
+// ─── Figma → DTCG conversion ─────────────────────────────────────────────────
+
+export function figmaNameToPath(figmaName) {
+  return figmaName.split("/").join(".");
+}
+
+export function colorToString(rgba) {
+  const { r, g, b, a } = rgba;
+  const to255 = (c) => Math.round(c * 255);
+  if (a < 0.999) {
+    return `rgba(${to255(r)}, ${to255(g)}, ${to255(b)}, ${parseFloat(a.toFixed(2))})`;
+  }
+  return (
+    "#" +
+    [r, g, b]
+      .map((c) => to255(c).toString(16).padStart(2, "0").toUpperCase())
+      .join("")
+  );
+}
+
+export function collectionToLayer(collection) {
+  if (!collection) return "unknown";
+  switch (collection.name) {
+    case "Foundation":
+      return "foundation";
+    case "Brand":
+      return "foundation";
+    case "Semantic":
+      return "semantic";
+    case "Component":
+      return "component";
+    default:
+      return collection.name.toLowerCase();
+  }
+}
+
+export function resolveValue(value, allVarsById, collectionsById) {
+  if (value == null) return null;
+
+  if (typeof value === "object" && value.type === "VARIABLE_ALIAS") {
+    const target = allVarsById[value.id];
+    if (!target) {
+      return { __error: "ALIAS_BROKEN", aliasId: value.id };
+    }
+    const targetColl = collectionsById[target.variableCollectionId];
+    const layer = collectionToLayer(targetColl);
+    const targetPath = figmaNameToPath(target.name);
+    return `{${layer}.${targetPath}}`;
+  }
+
+  if (typeof value === "object" && "r" in value && "g" in value && "b" in value) {
+    return colorToString(value);
+  }
+
+  return value;
+}
+
+export function mapDtcgType(figmaType) {
+  switch (figmaType) {
+    case "COLOR":
+      return "color";
+    case "FLOAT":
+      return "dimension";
+    case "STRING":
+      return "string";
+    case "BOOLEAN":
+      return "boolean";
+    default:
+      return "color";
+  }
+}
+
+/**
+ * Dado um Variable + collection, retorna o arquivo-alvo DTCG.
+ * Retorna { file, mode, semanticMulti? }. semanticMulti indica que
+ * gera em 2 arquivos (light.json e dark.json) — nesse caso, o caller
+ * trata separadamente.
+ */
+export function resolveTargetFile(variable, collection) {
+  if (!collection) return { file: null, mode: null };
+
+  if (collection.name === "Foundation") {
+    const prefix = variable.name.split("/")[0];
+    const file = FOUNDATION_PREFIX_TO_FILE[prefix];
+    return file ? { file: `foundation/${file}`, mode: "Value" } : { file: null, mode: null };
+  }
+
+  if (collection.name === "Brand") {
+    return { file: "foundation/brand.json", mode: BRAND_MODE };
+  }
+
+  if (collection.name === "Semantic") {
+    return { file: null, mode: null, semanticMulti: true };
+  }
+
+  if (collection.name === "Component") {
+    const prefix = variable.name.split("/")[0];
+    return { file: `component/${prefix}.json`, mode: COMPONENT_MODE };
+  }
+
+  return { file: null, mode: null };
+}
+
+/**
+ * Varre todas as Variables e constrói o estado esperado dos JSONs.
+ * Retorna { state, issues }:
+ *   state = { "foundation/colors.json": { "foundation.color.neutral.50": {$value,$type,$description} }, ... }
+ *   issues = [{ category: "ALIAS_BROKEN", token, mode, target }, ...]
+ */
+export function buildExpectedState(figmaMeta) {
+  const { variables, variableCollections } = figmaMeta;
+  const allVarsById = variables;
+  const collectionsById = variableCollections;
+  const issues = [];
+  const state = {};
+
+  for (const v of Object.values(variables)) {
+    const coll = collectionsById[v.variableCollectionId];
+    if (!coll) continue;
+    const layer = collectionToLayer(coll);
+    const canonicalPath = `${layer}.${figmaNameToPath(v.name)}`;
+    const target = resolveTargetFile(v, coll);
+
+    if (coll.name === "Semantic") {
+      for (const m of coll.modes) {
+        const file =
+          m.name === "Light" ? "semantic/light.json" :
+          m.name === "Dark" ? "semantic/dark.json" : null;
+        if (!file) continue;
+        const resolved = resolveValue(v.valuesByMode[m.modeId], allVarsById, collectionsById);
+        if (resolved && typeof resolved === "object" && resolved.__error) {
+          issues.push({ category: "ALIAS_BROKEN", token: canonicalPath, mode: m.name, target: resolved.aliasId });
+          continue;
+        }
+        if (!state[file]) state[file] = {};
+        state[file][canonicalPath] = {
+          $value: resolved,
+          $type: mapDtcgType(v.resolvedType),
+          ...(v.description ? { $description: v.description } : {}),
+        };
+      }
+      continue;
+    }
+
+    if (!target.file) continue;
+    const mode = coll.modes.find((m) => m.name === target.mode);
+    if (!mode) continue;
+    const resolved = resolveValue(v.valuesByMode[mode.modeId], allVarsById, collectionsById);
+    if (resolved && typeof resolved === "object" && resolved.__error) {
+      issues.push({ category: "ALIAS_BROKEN", token: canonicalPath, mode: target.mode, target: resolved.aliasId });
+      continue;
+    }
+    if (!state[target.file]) state[target.file] = {};
+    state[target.file][canonicalPath] = {
+      $value: resolved,
+      $type: mapDtcgType(v.resolvedType),
+      ...(v.description ? { $description: v.description } : {}),
+    };
+  }
+
+  return { state, issues };
+}
+
+// ─── Read current JSON state ────────────────────────────────────────────────
+
+export function flattenDtcg(obj, prefix = "", acc = {}) {
+  if (obj && typeof obj === "object" && "$value" in obj) {
+    acc[prefix] = obj;
+    return acc;
+  }
+  if (obj && typeof obj === "object") {
+    for (const [k, v] of Object.entries(obj)) {
+      if (k.startsWith("$")) continue;
+      flattenDtcg(v, prefix ? `${prefix}.${k}` : k, acc);
+    }
+  }
+  return acc;
+}
+
+export function readCurrentState(tokensDir) {
+  const state = {};
+  const readIfExists = (relFile) => {
+    const abs = path.join(tokensDir, relFile);
+    if (!fs.existsSync(abs)) return null;
+    return flattenDtcg(JSON.parse(fs.readFileSync(abs, "utf8")));
+  };
+  for (const f of Object.values(FOUNDATION_PREFIX_TO_FILE)) {
+    const rel = `foundation/${f}`;
+    const flat = readIfExists(rel);
+    if (flat) state[rel] = flat;
+  }
+  const brand = readIfExists("foundation/brand.json");
+  if (brand) state["foundation/brand.json"] = brand;
+  const light = readIfExists("semantic/light.json");
+  if (light) state["semantic/light.json"] = light;
+  const dark = readIfExists("semantic/dark.json");
+  if (dark) state["semantic/dark.json"] = dark;
+  const compDir = path.join(tokensDir, "component");
+  if (fs.existsSync(compDir)) {
+    for (const f of fs.readdirSync(compDir)) {
+      if (!f.endsWith(".json")) continue;
+      const rel = `component/${f}`;
+      const flat = readIfExists(rel);
+      if (flat) state[rel] = flat;
+    }
+  }
+  return state;
+}
+
+// ─── Compare ────────────────────────────────────────────────────────────────
+
+/**
+ * Converte valor de dimensão pra número em px. Retorna null se não for dimensão.
+ *   16     → 16 (Figma retorna números puros pra FLOAT)
+ *   "16px" → 16
+ *   "1rem" → 16
+ *   "1.5rem" → 24
+ */
+function asPx(v) {
+  if (typeof v === "number") return v;
+  if (typeof v !== "string") return null;
+  const s = v.trim().toLowerCase();
+  const rem = s.match(/^(-?[\d.]+)rem$/);
+  if (rem) return parseFloat(rem[1]) * 16;
+  const px = s.match(/^(-?[\d.]+)px$/);
+  if (px) return parseFloat(px[1]);
+  // Número puro em string
+  if (/^-?[\d.]+$/.test(s)) return parseFloat(s);
+  return null;
+}
+
+// Arredonda pra 4 casas decimais pra amortecer ruído de ponto flutuante do Figma
+// (ex.: 0.05 vs 0.05000000074505806) sem perder precisão útil (ex.: 1.5 ≠ 1.6).
+function roundFloat(n) {
+  return Math.round(n * 10000) / 10000;
+}
+
+export function normalizeForCompare(v) {
+  if (v == null) return "";
+  // Tenta dimensão primeiro
+  const px = asPx(v);
+  if (px != null) return `px:${roundFloat(px)}`;
+  if (typeof v === "object") return JSON.stringify(v);
+  let s = String(v).trim().toLowerCase();
+  if (/^#[0-9a-f]{3}$/.test(s)) s = "#" + s.slice(1).split("").map((c) => c + c).join("");
+  s = s.replace(/\s+/g, "");
+  // Normaliza números dentro de strings (ex.: rgba) arredondando pra 4 casas.
+  s = s.replace(/-?\d+\.\d+/g, (m) => String(roundFloat(parseFloat(m))));
+  return s;
+}
+
+/**
+ * Compara expected (Figma) vs actual (JSON). Retorna:
+ *   { VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA }
+ * Cada um é array de { file, token, figma?, json? }.
+ */
+export function compareStates(expected, actual) {
+  const diffs = { VALUE_DRIFT: [], NEW_IN_FIGMA: [], MISSING_IN_FIGMA: [] };
+  const allFiles = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  for (const file of allFiles) {
+    const exp = expected[file] || {};
+    const act = actual[file] || {};
+    const allKeys = new Set([...Object.keys(exp), ...Object.keys(act)]);
+    for (const key of allKeys) {
+      const e = exp[key];
+      const a = act[key];
+      if (e && !a) {
+        diffs.NEW_IN_FIGMA.push({ file, token: key, figma: e.$value });
+      } else if (!e && a) {
+        diffs.MISSING_IN_FIGMA.push({ file, token: key, json: a.$value });
+      } else if (e && a) {
+        if (normalizeForCompare(e.$value) !== normalizeForCompare(a.$value)) {
+          diffs.VALUE_DRIFT.push({ file, token: key, figma: e.$value, json: a.$value });
+        }
+      }
+    }
+  }
+  return diffs;
+}

--- a/scripts/sync-tokens-from-figma.mjs
+++ b/scripts/sync-tokens-from-figma.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * sync-tokens-from-figma.mjs — sincroniza Figma Variables para os arquivos
+ * JSON DTCG em `tokens/`.
+ *
+ * Direção canônica (ADR-003 revisada em 0.5.8): Figma é autoridade de
+ * valores de token. JSONs em tokens/ são consolidação derivada.
+ *
+ * COMO FUNCIONA NO PLANO PRO:
+ *   A REST API de Figma Variables exige plano Enterprise. No plano Pro
+ *   (nosso caso), o sync funciona via **snapshot JSON** gerado pelo MCP
+ *   remoto (`use_figma`) dentro de uma sessão Claude Code. Fluxo:
+ *
+ *     1. Agente Claude executa use_figma com código Plugin API que
+ *        serializa as Variables num JSON e salva em
+ *        `.figma-snapshot.json` (gitignored).
+ *     2. Este script lê esse snapshot.
+ *     3. Compara com tokens/. Em --write, aplica VALUE_DRIFT.
+ *
+ *   Ver docs/process-figma-sync.md pro passo-a-passo.
+ *
+ * Uso:
+ *   node scripts/sync-tokens-from-figma.mjs                                  (dry-run, lê .figma-snapshot.json)
+ *   node scripts/sync-tokens-from-figma.mjs --write                          (aplica VALUE_DRIFT e regenera CSS)
+ *   node scripts/sync-tokens-from-figma.mjs --snapshot path/to/other.json    (snapshot em outro caminho)
+ *
+ * Categorias (mesmas usadas em tokens-verify.mjs):
+ *   VALUE_DRIFT        mesmo nome, valor diferente. `--write` corrige.
+ *   NEW_IN_FIGMA       Figma tem, JSON não. `--write` não cria — ação manual.
+ *   MISSING_IN_FIGMA   JSON tem, Figma não. `--write` não deleta — ação manual.
+ *   ALIAS_BROKEN       variável Figma aponta pra ID inexistente.
+ *
+ * Exit codes:
+ *   0 — sem divergências ou --write bem sucedido.
+ *   1 — dry-run com divergências.
+ *   2 — erro de execução (snapshot ausente/inválido, build falhou).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import {
+  readFigmaSnapshot,
+  buildExpectedState,
+  readCurrentState,
+  compareStates,
+} from "./lib/figma-dtcg.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const TOKENS_DIR = path.join(ROOT, "tokens");
+
+const args = process.argv.slice(2);
+const isWrite = args.includes("--write");
+const snapshotFlagIdx = args.indexOf("--snapshot");
+const snapshotPath = path.resolve(
+  ROOT,
+  snapshotFlagIdx !== -1 && args[snapshotFlagIdx + 1]
+    ? args[snapshotFlagIdx + 1]
+    : ".figma-snapshot.json"
+);
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`sync-tokens-from-figma.mjs
+
+Uso:
+  node scripts/sync-tokens-from-figma.mjs                                  # dry-run
+  node scripts/sync-tokens-from-figma.mjs --write                          # aplica
+  node scripts/sync-tokens-from-figma.mjs --snapshot path/to/dump.json     # snapshot alternativo
+
+Espera um snapshot em .figma-snapshot.json (ou --snapshot <path>) no formato
+gerado pelo helper MCP. Ver docs/process-figma-sync.md pra detalhes.`);
+  process.exit(0);
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────────
+
+function fmt(v) {
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function report(diffs, issues) {
+  const total = diffs.VALUE_DRIFT.length + diffs.NEW_IN_FIGMA.length + diffs.MISSING_IN_FIGMA.length;
+  const aliasBroken = issues.filter((i) => i.category === "ALIAS_BROKEN").length;
+
+  console.log("");
+  console.log("═══ sync-tokens-from-figma ═════════════════════════════");
+  console.log(`VALUE_DRIFT      (mesmo nome, valor difere): ${diffs.VALUE_DRIFT.length}`);
+  console.log(`NEW_IN_FIGMA     (Figma tem, JSON não):      ${diffs.NEW_IN_FIGMA.length}`);
+  console.log(`MISSING_IN_FIGMA (JSON tem, Figma não):      ${diffs.MISSING_IN_FIGMA.length}`);
+  console.log(`ALIAS_BROKEN     (Figma aponta pra órfão):   ${aliasBroken}`);
+  console.log("═════════════════════════════════════════════════════════");
+
+  const section = (title, items, format) => {
+    if (!items.length) return;
+    console.log(`\n┌ ${title} `.padEnd(60, "─"));
+    for (const d of items.slice(0, 50)) console.log("  " + format(d));
+    if (items.length > 50) console.log(`  ... +${items.length - 50} mais`);
+  };
+
+  section(
+    "VALUE_DRIFT",
+    diffs.VALUE_DRIFT,
+    (d) => `${d.token}\n    Figma: ${fmt(d.figma)}\n    JSON:  ${fmt(d.json)}`
+  );
+  section(
+    "NEW_IN_FIGMA (requer adição manual)",
+    diffs.NEW_IN_FIGMA,
+    (d) => `${d.token} = ${fmt(d.figma)} → ${d.file}`
+  );
+  section(
+    "MISSING_IN_FIGMA (requer remoção manual ou adição no Figma)",
+    diffs.MISSING_IN_FIGMA,
+    (d) => `${d.token} (valor JSON: ${fmt(d.json)}) ← ${d.file}`
+  );
+  section(
+    "ALIAS_BROKEN",
+    issues.filter((i) => i.category === "ALIAS_BROKEN"),
+    (i) => `${i.token}${i.mode ? ` (${i.mode})` : ""} → alvo: ${i.target}`
+  );
+
+  console.log("");
+  return total;
+}
+
+// ─── Write ──────────────────────────────────────────────────────────────────
+
+function applyValueDrifts(drifts) {
+  const byFile = {};
+  for (const d of drifts) (byFile[d.file] ||= []).push(d);
+
+  for (const [relFile, fixes] of Object.entries(byFile)) {
+    const abs = path.join(TOKENS_DIR, relFile);
+    const json = JSON.parse(fs.readFileSync(abs, "utf8"));
+    for (const fix of fixes) {
+      const parts = fix.token.split(".");
+      let cur = json;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (!cur || !(parts[i] in cur)) {
+          console.warn(`  [skip] ${fix.token}: path ausente em ${relFile}`);
+          cur = null;
+          break;
+        }
+        cur = cur[parts[i]];
+      }
+      if (!cur) continue;
+      const leaf = parts[parts.length - 1];
+      if (!cur[leaf] || typeof cur[leaf] !== "object" || !("$value" in cur[leaf])) {
+        console.warn(`  [skip] ${fix.token}: folha inválida em ${relFile}`);
+        continue;
+      }
+      cur[leaf].$value = fix.figma;
+    }
+    fs.writeFileSync(abs, JSON.stringify(json, null, 2) + "\n");
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Lendo snapshot Figma em ${path.relative(ROOT, snapshotPath)}...`);
+  const meta = readFigmaSnapshot(snapshotPath);
+  console.log(
+    `  ${Object.keys(meta.variables).length} variables em ${Object.keys(meta.variableCollections).length} collections`
+  );
+
+  console.log("Construindo estado esperado...");
+  const { state: expected, issues } = buildExpectedState(meta);
+
+  console.log("Lendo JSONs atuais...");
+  const actual = readCurrentState(TOKENS_DIR);
+
+  console.log("Comparando...");
+  const diffs = compareStates(expected, actual);
+  const total = report(diffs, issues);
+
+  if (!isWrite) {
+    if (total === 0) {
+      console.log("Figma e JSON em dia.");
+      process.exit(0);
+    }
+    console.log(
+      `Dry-run: ${total} divergência(s). Use --write pra aplicar VALUE_DRIFT (${diffs.VALUE_DRIFT.length}).`
+    );
+    process.exit(1);
+  }
+
+  if (diffs.VALUE_DRIFT.length === 0) {
+    console.log("Nada a aplicar (VALUE_DRIFT vazio).");
+    if (diffs.NEW_IN_FIGMA.length || diffs.MISSING_IN_FIGMA.length) {
+      console.log("Há pendências que exigem revisão manual — ver relatório acima.");
+    }
+    process.exit(0);
+  }
+
+  console.log(`Aplicando ${diffs.VALUE_DRIFT.length} VALUE_DRIFT(s)...`);
+  applyValueDrifts(diffs.VALUE_DRIFT);
+
+  for (const step of ["build:tokens", "sync:docs"]) {
+    console.log(`Rodando npm run ${step}...`);
+    const r = spawnSync("npm", ["run", step], { cwd: ROOT, stdio: "inherit" });
+    if (r.status !== 0) {
+      console.error(`${step} falhou.`);
+      process.exit(2);
+    }
+  }
+
+  console.log("");
+  console.log("✅ VALUE_DRIFT aplicados. Revisar git diff antes de commitar.");
+  if (diffs.NEW_IN_FIGMA.length || diffs.MISSING_IN_FIGMA.length) {
+    console.log("⚠ Pendências NEW_IN_FIGMA / MISSING_IN_FIGMA exigem ação manual. Ver relatório.");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

- Adapta o sync revertido em 0.5.9 pra rodar via MCP (`use_figma`) em vez da REST API Enterprise-only.
- Agente Claude Code dumpa ~462 Variables em `.figma-snapshot.json` (gitignored) em chunks (~20KB por chamada do MCP), e `scripts/sync-tokens-from-figma.mjs` compara com `tokens/**/*.json`.
- Categorias: VALUE_DRIFT (auto-corrigível com `--write`), NEW_IN_FIGMA, MISSING_IN_FIGMA, ALIAS_BROKEN.
- Fluxo manual documentado em `docs/process-figma-sync.md`. Automação em CI continua no backlog.

## Arquivos

- `scripts/sync-tokens-from-figma.mjs` + `scripts/lib/figma-dtcg.mjs` (recuperados de 9d531a8, adaptados).
- `docs/process-figma-sync.md` (novo).
- `.gitignore`: `.figma-snapshot.json` + variações.
- `package.json`: `sync:tokens-from-figma` e `sync:tokens-from-figma:write`.
- CLAUDE.md: regras de ouro com fluxo MCP concreto.
- `docs/backlog.md`: item refraseado pra "Automatizar em CI".
- Bump 0.5.9 → 0.5.10.

## Test plan

- [x] Snapshot gerado via MCP (462 vars em 4 collections)
- [x] `npm run sync:tokens-from-figma` dry-run roda e reporta divergências (118 VALUE_DRIFT, 56 NEW_IN_FIGMA, 74 MISSING_IN_FIGMA, 0 ALIAS_BROKEN)
- [x] `npm run build:all` passa
- [ ] Validar manualmente as divergências não são false-positives antes de rodar `--write` (em PR separada)

## Notas

- 118 VALUE_DRIFT mostram que Figma e JSON **realmente** divergiram nos últimos ciclos — muito do que está no JSON não reflete o estado atual do Figma. Isso é esperado: em 0.5.8 estabelecemos Figma como autoridade, mas até agora não tínhamos o sync funcionando. O PR de aplicação (`--write`) deve ser separado, permitindo review caso a caso.
- NEW_IN_FIGMA e MISSING_IN_FIGMA têm majoritariamente tokens de tipografia — provável desalinhamento de naming (`font/*` no Figma vs `foundation.typography.font.*` em JSON). Investigar antes de considerar qualquer adição/remoção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)