### PR TITLE
fix(docs): audit completo foundations + fixes (0.5.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.13]
+
+### Corrigido
+Audit completo dos 9 arquivos `foundations-*.html` restantes (após PR #19 auto-gerar `theme-colors`). Descobertos 3 arquivos com drift real:
+
+- **`foundations-motion.html`**: `--ds-duration-fast` mostrava `100ms` mas CSS real é `150ms` (divergência em 2 lugares — label demo + tabela). Tabela de easings usava keywords CSS imprecisas (`ease`, `ease-in`, `ease-out`, `ease-in-out`) — o CSS real usa `cubic-bezier(0.4, 0, 0.2, 1)` etc, que **não são equivalentes** às keywords. Corrigido: duration, tabela com valores cubic-bezier reais, labels demo com descrição semântica (`padrão`, `acelerando`, `desacelerando`, `suave`) em vez de keyword enganosa.
+- **`foundations-opacity.html`**: `<code>--ds-color-overlay-black-5</code>` era **token fantasma** — o nome CSS correto é `--ds-overlay-black-5` (sem `color-`). Corrigido.
+- **`foundations-borders.html`**: duas tabelas de cores de borda (`Border Colors`, `Feedback Border Colors`) estavam com 7 valores desatualizados pós PR #18 **e** duplicavam informação já presente em `foundations-theme-colors.html` (que é auto-gerada). Removidas; substituídas por parágrafo linkando pra Theme Colors. Mantida só a tabela de `Border Widths`, que está correta.
+
+### Confirmado em dia
+`foundations-typography.html`, `foundations-spacing.html`, `foundations-radius.html`, `foundations-elevation.html`, `foundations-zindex.html`, `foundations-colors.html` — 0 drift. Os "falsos positivos" do audit automático eram tabelas conceituais (elevation mapeia "nível → combinação de tokens"; zindex mostra "uso por token"; opacity é `<div>` custom não `<table>`) que o parser genérico confundiu com tabelas de valor.
+
+### Notas
+- Princípio de não-duplicação aplicado: quando um token semântico tem seu valor canônico em `foundations-theme-colors.html`, outras páginas de foundation **não** repetem — linkam. Evita drift futuro.
+- Próximo passo: revisão equivalente nas camadas **Semantic** e **Component** (páginas de docs e Figma).
+
 ## [0.5.12]
 
 ### Corrigido

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T20:48:28.624Z",
-  "version": "0.5.12",
+  "generatedAt": "2026-04-21T21:08:27.301Z",
+  "version": "0.5.13",
   "count": 11,
   "adrs": [
     {

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T20:48:28.624Z",
-  "version": "0.5.12",
+  "generatedAt": "2026-04-21T21:08:27.301Z",
+  "version": "0.5.13",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T20:48:28.624Z",
-  "version": "0.5.12",
+  "generatedAt": "2026-04-21T21:08:27.301Z",
+  "version": "0.5.13",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T20:48:29.078Z",
+  "generatedAt": "2026-04-21T21:08:27.765Z",
   "totals": {
     "jsonTokens": 632,
     "sharedTokens": 368,

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T20:48:28.624Z",
-  "version": "0.5.12",
+  "generatedAt": "2026-04-21T21:08:27.301Z",
+  "version": "0.5.13",
   "counts": {
     "foundation": 231,
     "semanticLight": 132,

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,21 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.13]</h2>
+<h3>Corrigido</h3>
+<p>Audit completo dos 9 arquivos <code>foundations-*.html</code> restantes (após PR #19 auto-gerar <code>theme-colors</code>). Descobertos 3 arquivos com drift real:</p>
+<ul>
+<li><strong><code>foundations-motion.html</code></strong>: <code>--ds-duration-fast</code> mostrava <code>100ms</code> mas CSS real é <code>150ms</code> (divergência em 2 lugares — label demo + tabela). Tabela de easings usava keywords CSS imprecisas (<code>ease</code>, <code>ease-in</code>, <code>ease-out</code>, <code>ease-in-out</code>) — o CSS real usa <code>cubic-bezier(0.4, 0, 0.2, 1)</code> etc, que <strong>não são equivalentes</strong> às keywords. Corrigido: duration, tabela com valores cubic-bezier reais, labels demo com descrição semântica (<code>padrão</code>, <code>acelerando</code>, <code>desacelerando</code>, <code>suave</code>) em vez de keyword enganosa.</li>
+<li><strong><code>foundations-opacity.html</code></strong>: <code>&lt;code&gt;--ds-color-overlay-black-5&lt;/code&gt;</code> era <strong>token fantasma</strong> — o nome CSS correto é <code>--ds-overlay-black-5</code> (sem <code>color-</code>). Corrigido.</li>
+<li><strong><code>foundations-borders.html</code></strong>: duas tabelas de cores de borda (<code>Border Colors</code>, <code>Feedback Border Colors</code>) estavam com 7 valores desatualizados pós PR #18 <strong>e</strong> duplicavam informação já presente em <code>foundations-theme-colors.html</code> (que é auto-gerada). Removidas; substituídas por parágrafo linkando pra Theme Colors. Mantida só a tabela de <code>Border Widths</code>, que está correta.</li>
+</ul>
+<h3>Confirmado em dia</h3>
+<p><code>foundations-typography.html</code>, <code>foundations-spacing.html</code>, <code>foundations-radius.html</code>, <code>foundations-elevation.html</code>, <code>foundations-zindex.html</code>, <code>foundations-colors.html</code> — 0 drift. Os &quot;falsos positivos&quot; do audit automático eram tabelas conceituais (elevation mapeia &quot;nível → combinação de tokens&quot;; zindex mostra &quot;uso por token&quot;; opacity é <code>&lt;div&gt;</code> custom não <code>&lt;table&gt;</code>) que o parser genérico confundiu com tabelas de valor.</p>
+<h3>Notas</h3>
+<ul>
+<li>Princípio de não-duplicação aplicado: quando um token semântico tem seu valor canônico em <code>foundations-theme-colors.html</code>, outras páginas de foundation <strong>não</strong> repetem — linkam. Evita drift futuro.</li>
+<li>Próximo passo: revisão equivalente nas camadas <strong>Semantic</strong> e <strong>Component</strong> (páginas de docs e Figma).</li>
+</ul>
 <h2>[0.5.12]</h2>
 <h3>Corrigido</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.12**
+> Versão atual: **0.5.13**
 
 ## Status geral
 

--- a/docs/foundations-borders.html
+++ b/docs/foundations-borders.html
@@ -100,30 +100,10 @@
 
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Border Colors</span><span data-lang="en">Border Colors</span></h2>
-    <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Amostra</span><span data-lang="en">Swatch</span></th><th>Token</th><th>Light</th><th>Dark</th></tr></thead>
-      <tbody>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-default)"></span></td><td><code>--ds-border-default</code></td><td><code>neutral-200</code></td><td><code>neutral-700</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-strong)"></span></td><td><code>--ds-border-strong</code></td><td><code>neutral-400</code></td><td><code>neutral-500</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-subtle)"></span></td><td><code>--ds-border-subtle</code></td><td><code>neutral-100</code></td><td><code>neutral-800</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-focus)"></span></td><td><code>--ds-border-focus</code></td><td><code>primary</code></td><td><code>primary</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-brand)"></span></td><td><code>--ds-border-brand</code></td><td><code>primary</code></td><td><code>primary</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-border-error)"></span></td><td><code>--ds-border-error</code></td><td><code>red-600</code></td><td><code>red-500</code></td></tr>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="ds-subsection">
-    <h2 class="ds-subsection__title"><span data-lang="pt">Feedback Border Colors</span><span data-lang="en">Feedback Border Colors</span></h2>
-    <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Amostra</span><span data-lang="en">Swatch</span></th><th>Token</th><th>Light</th><th>Dark</th></tr></thead>
-      <tbody>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-feedback-success-border)"></span></td><td><code>--ds-feedback-success-border</code></td><td><code>green-600</code></td><td><code>green-500</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-feedback-warning-border)"></span></td><td><code>--ds-feedback-warning-border</code></td><td><code>amber-500</code></td><td><code>amber-400</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-feedback-error-border)"></span></td><td><code>--ds-feedback-error-border</code></td><td><code>red-600</code></td><td><code>red-500</code></td></tr>
-        <tr><td><span class="ds-token-swatch" style="background-color:var(--ds-feedback-info-border)"></span></td><td><code>--ds-feedback-info-border</code></td><td><code>sky-600</code></td><td><code>sky-400</code></td></tr>
-      </tbody>
-    </table>
+    <p style="color:var(--ds-content-secondary);">
+      <span data-lang="pt">Cores de borda semânticas (<code>--ds-border-default</code>, <code>--ds-border-focus</code>, <code>--ds-feedback-*-border</code>, etc) vivem na camada semântica e adaptam ao modo light/dark. A referência completa com valores light/dark está em <a href="foundations-theme-colors.html">Theme Colors</a>, nas seções <strong>Border</strong> e <strong>Feedback</strong>.</span>
+      <span data-lang="en">Semantic border colors (<code>--ds-border-default</code>, <code>--ds-border-focus</code>, <code>--ds-feedback-*-border</code>, etc) live in the semantic layer and adapt to light/dark mode. The full reference with light/dark values is in <a href="foundations-theme-colors.html">Theme Colors</a>, under <strong>Border</strong> and <strong>Feedback</strong> sections.</span>
+    </p>
   </div>
 </main>
 

--- a/docs/foundations-motion.html
+++ b/docs/foundations-motion.html
@@ -73,7 +73,7 @@
     <p style="margin-bottom:var(--ds-spacing-4);color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);"><span data-lang="pt">Passe o mouse sobre cada linha para ver o timing em ação.</span><span data-lang="en">Hover over each row to see the timing in action.</span></p>
 
     <div class="ds-motion-demo ds-motion-demo--fast">
-      <div class="ds-motion-demo__label"><code>--ds-duration-fast</code><br>100ms</div>
+      <div class="ds-motion-demo__label"><code>--ds-duration-fast</code><br>150ms</div>
       <div class="ds-motion-demo__track"><div class="ds-motion-demo__runner"></div></div>
     </div>
 
@@ -90,7 +90,7 @@
     <table class="ds-token-table">
       <thead><tr><th>Token</th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
-        <tr><td><code>--ds-duration-fast</code></td><td>100ms</td><td><span data-lang="pt">Micro-interações: mudanças de cor no hover, transições de opacidade, troca de ícones</span><span data-lang="en">Micro-interactions: color changes on hover, opacity shifts, icon swaps</span></td></tr>
+        <tr><td><code>--ds-duration-fast</code></td><td>150ms</td><td><span data-lang="pt">Micro-interações: mudanças de cor no hover, transições de opacidade, troca de ícones</span><span data-lang="en">Micro-interactions: color changes on hover, opacity shifts, icon swaps</span></td></tr>
         <tr><td><code>--ds-duration-normal</code></td><td>200ms</td><td><span data-lang="pt">Transições padrão: estados de button, foco de input, mudanças de cor de borda</span><span data-lang="en">Standard transitions: button states, input focus, border color changes</span></td></tr>
         <tr><td><code>--ds-duration-slow</code></td><td>300ms</td><td><span data-lang="pt">Movimentos maiores: modais, sidesheets, expandir/recolher accordion</span><span data-lang="en">Larger movements: modals, sidesheets, accordion expand/collapse</span></td></tr>
       </tbody>
@@ -102,32 +102,32 @@
     <p style="margin-bottom:var(--ds-spacing-4);color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);"><span data-lang="pt">Todos os demos usam <code>--ds-duration-normal</code> (200ms). Passe o mouse para comparar curvas.</span><span data-lang="en">All demos use <code>--ds-duration-normal</code> (200ms). Hover to compare curves.</span></p>
 
     <div class="ds-motion-demo ds-motion-demo--normal">
-      <div class="ds-motion-demo__label"><code>--ds-ease-default</code><br>ease</div>
+      <div class="ds-motion-demo__label"><code>--ds-ease-default</code><br><span data-lang="pt">padrão</span><span data-lang="en">default</span></div>
       <div class="ds-motion-demo__track"><div class="ds-motion-demo__runner"></div></div>
     </div>
 
     <div class="ds-motion-demo ds-motion-demo--ease-in">
-      <div class="ds-motion-demo__label"><code>--ds-ease-in</code><br>ease-in</div>
+      <div class="ds-motion-demo__label"><code>--ds-ease-in</code><br><span data-lang="pt">acelerando</span><span data-lang="en">accelerating</span></div>
       <div class="ds-motion-demo__track"><div class="ds-motion-demo__runner"></div></div>
     </div>
 
     <div class="ds-motion-demo ds-motion-demo--ease-out">
-      <div class="ds-motion-demo__label"><code>--ds-ease-out</code><br>ease-out</div>
+      <div class="ds-motion-demo__label"><code>--ds-ease-out</code><br><span data-lang="pt">desacelerando</span><span data-lang="en">decelerating</span></div>
       <div class="ds-motion-demo__track"><div class="ds-motion-demo__runner"></div></div>
     </div>
 
     <div class="ds-motion-demo ds-motion-demo--ease-in-out">
-      <div class="ds-motion-demo__label"><code>--ds-ease-in-out</code><br>ease-in-out</div>
+      <div class="ds-motion-demo__label"><code>--ds-ease-in-out</code><br><span data-lang="pt">suave</span><span data-lang="en">smooth</span></div>
       <div class="ds-motion-demo__track"><div class="ds-motion-demo__runner"></div></div>
     </div>
 
     <table class="ds-token-table">
       <thead><tr><th>Token</th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
-        <tr><td><code>--ds-ease-default</code></td><td>ease</td><td><span data-lang="pt">Uso geral: maioria das transições de componentes</span><span data-lang="en">General-purpose: most component transitions</span></td></tr>
-        <tr><td><code>--ds-ease-in</code></td><td>ease-in</td><td><span data-lang="pt">Elementos saindo da viewport ou desaparecendo</span><span data-lang="en">Elements exiting the viewport or fading out</span></td></tr>
-        <tr><td><code>--ds-ease-out</code></td><td>ease-out</td><td><span data-lang="pt">Elementos entrando na viewport, modais aparecendo</span><span data-lang="en">Elements entering the viewport, modals appearing</span></td></tr>
-        <tr><td><code>--ds-ease-in-out</code></td><td>ease-in-out</td><td><span data-lang="pt">Elementos que mudam de posição dentro da viewport</span><span data-lang="en">Elements that move position within the viewport</span></td></tr>
+        <tr><td><code>--ds-ease-default</code></td><td><code>cubic-bezier(0.4, 0, 0.2, 1)</code></td><td><span data-lang="pt">Uso geral: maioria das transições de componentes</span><span data-lang="en">General-purpose: most component transitions</span></td></tr>
+        <tr><td><code>--ds-ease-in</code></td><td><code>cubic-bezier(0.4, 0, 1, 1)</code></td><td><span data-lang="pt">Elementos saindo da viewport ou desaparecendo</span><span data-lang="en">Elements exiting the viewport or fading out</span></td></tr>
+        <tr><td><code>--ds-ease-out</code></td><td><code>cubic-bezier(0, 0, 0.2, 1)</code></td><td><span data-lang="pt">Elementos entrando na viewport, modais aparecendo</span><span data-lang="en">Elements entering the viewport, modals appearing</span></td></tr>
+        <tr><td><code>--ds-ease-in-out</code></td><td><code>cubic-bezier(0.4, 0, 0.2, 1)</code></td><td><span data-lang="pt">Elementos que mudam de posição dentro da viewport</span><span data-lang="en">Elements that move position within the viewport</span></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/foundations-opacity.html
+++ b/docs/foundations-opacity.html
@@ -119,7 +119,7 @@
       <thead><tr><th><span data-lang="pt">Abordagem</span><span data-lang="en">Approach</span></th><th><span data-lang="pt">Exemplo de token</span><span data-lang="en">Token example</span></th><th><span data-lang="pt">Afeta</span><span data-lang="en">Affects</span></th><th><span data-lang="pt">Usar quando</span><span data-lang="en">Use when</span></th></tr></thead>
       <tbody>
         <tr><td>Opacity</td><td><code>--ds-opacity-50</code></td><td><span data-lang="pt">Elemento inteiro + filhos</span><span data-lang="en">Entire element + children</span></td><td><span data-lang="pt">Desabilitando um elemento complexo (button com ícone + texto)</span><span data-lang="en">Disabling a complex element (button with icon + text)</span></td></tr>
-        <tr><td>Overlay</td><td><code>--ds-color-overlay-black-5</code></td><td><span data-lang="pt">Somente fundo</span><span data-lang="en">Background only</span></td><td><span data-lang="pt">Tingimento hover/pressionado em superfícies interativas</span><span data-lang="en">Hover/pressed tint on interactive surfaces</span></td></tr>
+        <tr><td>Overlay</td><td><code>--ds-overlay-black-5</code></td><td><span data-lang="pt">Somente fundo</span><span data-lang="en">Background only</span></td><td><span data-lang="pt">Tingimento hover/pressionado em superfícies interativas</span><span data-lang="en">Hover/pressed tint on interactive surfaces</span></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.5.12. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.5.13. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -311,6 +311,22 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em `docs/process-versioning.html`.
 
 ## [Não publicado]
+
+## [0.5.13]
+
+### Corrigido
+Audit completo dos 9 arquivos `foundations-*.html` restantes (após PR #19 auto-gerar `theme-colors`). Descobertos 3 arquivos com drift real:
+
+- **`foundations-motion.html`**: `--ds-duration-fast` mostrava `100ms` mas CSS real é `150ms` (divergência em 2 lugares — label demo + tabela). Tabela de easings usava keywords CSS imprecisas (`ease`, `ease-in`, `ease-out`, `ease-in-out`) — o CSS real usa `cubic-bezier(0.4, 0, 0.2, 1)` etc, que **não são equivalentes** às keywords. Corrigido: duration, tabela com valores cubic-bezier reais, labels demo com descrição semântica (`padrão`, `acelerando`, `desacelerando`, `suave`) em vez de keyword enganosa.
+- **`foundations-opacity.html`**: `<code>--ds-color-overlay-black-5</code>` era **token fantasma** — o nome CSS correto é `--ds-overlay-black-5` (sem `color-`). Corrigido.
+- **`foundations-borders.html`**: duas tabelas de cores de borda (`Border Colors`, `Feedback Border Colors`) estavam com 7 valores desatualizados pós PR #18 **e** duplicavam informação já presente em `foundations-theme-colors.html` (que é auto-gerada). Removidas; substituídas por parágrafo linkando pra Theme Colors. Mantida só a tabela de `Border Widths`, que está correta.
+
+### Confirmado em dia
+`foundations-typography.html`, `foundations-spacing.html`, `foundations-radius.html`, `foundations-elevation.html`, `foundations-zindex.html`, `foundations-colors.html` — 0 drift. Os "falsos positivos" do audit automático eram tabelas conceituais (elevation mapeia "nível → combinação de tokens"; zindex mostra "uso por token"; opacity é `<div>` custom não `<table>`) que o parser genérico confundiu com tabelas de valor.
+
+### Notas
+- Princípio de não-duplicação aplicado: quando um token semântico tem seu valor canônico em `foundations-theme-colors.html`, outras páginas de foundation **não** repetem — linkam. Evita drift futuro.
+- Próximo passo: revisão equivalente nas camadas **Semantic** e **Component** (páginas de docs e Figma).
 
 ## [0.5.12]
 
@@ -751,7 +767,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.12**
+> Versão atual: **0.5.13**
 
 ## Status geral
 
@@ -1363,13 +1379,13 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.12**
+> Versão atual: **0.5.13**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.12 |
+| Versão | 0.5.13 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -2803,6 +2819,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T20:48:28.851Z
-Versão: 0.5.12
+Gerado por scripts/build-llms.mjs em 2026-04-21T21:08:27.530Z
+Versão: 0.5.13
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.12. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.13. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -89,4 +89,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T20:48:28.851Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T21:08:27.530Z.

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.12**
+> Versão atual: **0.5.13**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.12 |
+| Versão | 0.5.13 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,7 +63,7 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T20:48:29.078Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T21:08:27.765Z</div>
       <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.12 -->v0.5.12</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.13 -->v0.5.13</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",


### PR DESCRIPTION
## Summary

Follow-up da PR #19. Audit dos 9 arquivos `foundations-*.html` restantes (theme-colors já é auto-gerado). Descobertos 3 com drift real:

| Arquivo | Problema | Fix |
|---|---|---|
| **motion** | `duration-fast = 100ms` mas CSS é `150ms` (2 lugares). Tabela de easing usava keywords CSS (`ease`, `ease-in`) que **não são equivalentes** aos cubic-bezier do DS | Tabela com cubic-bezier real; labels demo com descrição semântica (`padrão`/`acelerando`/`desacelerando`/`suave`) |
| **opacity** | `--ds-color-overlay-black-5` era **fantasma** (nome CSS real é `--ds-overlay-black-5`) | Corrigido |
| **borders** | 2 tabelas de cor (7 valores desatualizados pós PR #18 + duplicavam `theme-colors.html`) | Removidas; substituídas por link pra Theme Colors. Mantida tabela Border Widths (correta) |

## Confirmado em dia

`typography`, `spacing`, `radius`, `elevation`, `zindex`, `colors` — 0 drift.

Os falsos positivos do audit automático eram tabelas **conceituais**:
- `elevation` mapeia `nível → combinação de (shadow + surface)`
- `zindex` mostra `token → uso` (valor numérico aparece, parser só não detectou)
- `opacity` tem `<div>` custom com valor+descrição juntos (não `<table>`)

## Princípio aplicado

**Não duplicação**: quando um token semântico tem valor canônico em `foundations-theme-colors.html`, outras páginas de foundation não repetem — linkam. Evita drift futuro.

## Test plan

- [x] `npm run build:all` passa (0 avisos, 0 erros)
- [x] Audit automático: 0 drifts em typography, spacing, radius, borders, motion, opacity
- [ ] Verificar visualmente no site pós-deploy que `motion.html` mostra `150ms` + cubic-bezier corretos; `borders.html` tem o link pra theme-colors; `opacity.html` sem fantasma

## Próximo passo

Revisão equivalente nas camadas **Semantic** (`tokens/semantic/` e docs) e **Component** (tokens + CSS + Figma) — pedido do usuário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)