### PR TITLE
fix(docs): audit Component layer + 66 renames (0.5.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.14]
+
+### Corrigido
+Audit da camada Component (19 docs HTML de componentes + meta-docs) revelou **49 paths token inválidos + 14 CSS vars fantasmas** — todos decorrentes de naming pré-ADR-011 (renames que a camada de dados incorporou mas a doc não). Corrigido em massa:
+
+- **`semantic.color.primary.*` → `semantic.brand.*`** (ADR-011): 15+ ocorrências em avatar, badge, button, checkbox, radio, spinner, tabs, textarea, toggle, etc. Incluindo sub-renames:
+  - `.primary.foreground` → `.brand.content.contrast`
+  - `.primary.text` → `.brand.content.default`
+- **`semantic.text.*` → `semantic.content.*`** (ADR-011): em breadcrumb, button, form-field, input, select, tabs, textarea, token-architecture. Inclui `.text.link.*` → `.content.link.*`.
+- **`semantic.state.disabled.foreground` → `semantic.content.disabled`** (ADR-011): button, select.
+- **`semantic.feedback.*.foreground|text` → `semantic.feedback.*.content.default`**: alert, textarea, form-field.
+- **`semantic.border.hover` → `semantic.border.control.hover`** (ADR-009): select, textarea.
+- **`semantic.radius.*` → `foundation.radius.*`** (radius é Foundation, não Semantic): card, checkbox, modal, radio, skeleton, tooltip.
+- **`foundation.z-index.*` → `foundation.z.*`**: modal, tooltip.
+- **`foundation.motion.duration.*` → `foundation.duration.*`**: spinner.
+- **`semantic.background.muted` → `semantic.state.disabled.background`**: skeleton.
+- **`--ds-typography-control-font-size-*` → `--ds-control-font-size-*`**: button, input, select, textarea. O Style Dictionary faz strip-layer removendo `typography`; a doc mantinha o nome pre-strip.
+- **`--ds-border-hover` → `--ds-border-control-hover`**: select, textarea.
+
+Também em `docs/token-architecture.html`: exemplo de component token atualizado de `--ds-button-bg-brand-default` (inexistente) para `--ds-button-background-toned-default` (real, criado no PR #18).
+
+E em `docs/brand-principles.md`: `foundation.color.brand.primary/secondary/accent` → `foundation.brand.primary/secondary` (`.accent` nunca existiu — só primary e secondary em Foundation; marcado como "não definido" até virar ADR).
+
+**Total: 66 renames em 19 arquivos.** Audit residual: 2 "fantasmas" remanescentes são bad examples didáticos intencionais (`--ds-red-600` em `design-principles.html` dizendo "não use" + `--ds-color-primary` em `token-architecture.html` dizendo "não colapse"). Ficam.
+
+### Observações do audit (não aplicadas nesta PR)
+
+**Semantic: 18 tokens órfãos** (declarados mas nenhum componente consome): 3 border-widths extras, 5 `space-inset-*`, 6 `space-component-*`, 4 `space-section-*`. Decisão pendente (remover / manter / caso a caso).
+
+**Component: 19 tokens órfãos** declarados no JSON mas não consumidos pelo CSS do próprio componente:
+- `button` (6): `background/foreground-toned-*` (criados no PR #18, CSS ainda usa semantic direto — refatoração pendente)
+- `checkbox` (6): `check-width/height-sm/md/lg` (CSS provavelmente desenha via SVG/stroke, não consome)
+- `input`, `select` (3 cada): `padding-y-sm/md/lg` (CSS usa height pra controlar Y, não padding-y)
+- `modal` (1): `padding`
+
+### Notas
+- Audit confirmou: **11 componentes têm tokens JSON**, **7 não têm e consomem semantic direto** (alert, badge, breadcrumb, card, divider, tabs, tooltip — arquiteturalmente OK pela ADR-001: camada component é opcional).
+- **Paridade light/dark: perfeita** (132 = 132, 0 divergência de tipo).
+- Próximo passo: decisão sobre os 37 órfãos totais (18 semantic + 19 component) + audit da camada Foundation.
+
 ## [0.5.13]
 
 ### Corrigido

--- a/docs/alert.html
+++ b/docs/alert.html
@@ -479,7 +479,7 @@
         <tr><td>bg (success filled)</td><td><code>semantic.feedback.success.default</code></td><td><code>--ds-feedback-success-default</code></td></tr>
         <tr><td>bg (success subtle)</td><td><code>semantic.feedback.success.background</code></td><td><code>--ds-feedback-success-background</code></td></tr>
         <tr><td>border (success subtle)</td><td><code>semantic.feedback.success.border</code></td><td><code>--ds-feedback-success-border</code></td></tr>
-        <tr><td>text (success)</td><td><code>semantic.feedback.success.foreground</code></td><td><code>--ds-feedback-success-content-contrast</code></td></tr>
+        <tr><td>text (success)</td><td><code>semantic.feedback.success.content.default</code></td><td><code>--ds-feedback-success-content-contrast</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-component</code></td></tr>
         <tr><td>padding</td><td><code>semantic.space.inset.md</code></td><td><code>--ds-space-inset-md</code></td></tr>
       </tbody>

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T21:09:13.513Z",
-  "version": "0.5.13",
+  "generatedAt": "2026-04-21T21:30:07.982Z",
+  "version": "0.5.14",
   "count": 11,
   "adrs": [
     {

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T21:09:13.513Z",
-  "version": "0.5.13",
+  "generatedAt": "2026-04-21T21:30:07.982Z",
+  "version": "0.5.14",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T21:09:13.513Z",
-  "version": "0.5.13",
+  "generatedAt": "2026-04-21T21:30:07.982Z",
+  "version": "0.5.14",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T21:09:13.975Z",
+  "generatedAt": "2026-04-21T21:30:08.435Z",
   "totals": {
     "jsonTokens": 632,
     "sharedTokens": 368,

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T21:09:13.513Z",
-  "version": "0.5.13",
+  "generatedAt": "2026-04-21T21:30:07.982Z",
+  "version": "0.5.14",
   "counts": {
     "foundation": 231,
     "semanticLight": 132,

--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -240,8 +240,8 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">fundo (fallback)</span><span data-lang="en">background (fallback)</span></td><td><code>semantic.color.primary.subtle</code></td><td><code>--ds-brand-subtle</code></td></tr>
-        <tr><td><span data-lang="pt">texto (iniciais)</span><span data-lang="en">text (initials)</span></td><td><code>semantic.color.primary.text</code></td><td><code>--ds-brand-content-default</code></td></tr>
+        <tr><td><span data-lang="pt">fundo (fallback)</span><span data-lang="en">background (fallback)</span></td><td><code>semantic.brand.subtle</code></td><td><code>--ds-brand-subtle</code></td></tr>
+        <tr><td><span data-lang="pt">texto (iniciais)</span><span data-lang="en">text (initials)</span></td><td><code>semantic.brand.content.default</code></td><td><code>--ds-brand-content-default</code></td></tr>
         <tr><td>border-radius</td><td><code>foundation.radius.full</code></td><td><code>--ds-radius-full</code></td></tr>
       </tbody>
     </table>

--- a/docs/badge.html
+++ b/docs/badge.html
@@ -262,10 +262,10 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td>bg (primary solid)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td>text (primary solid)</td><td><code>semantic.color.primary.foreground</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
-        <tr><td>bg (primary subtle)</td><td><code>semantic.color.primary.subtle</code></td><td><code>--ds-brand-subtle</code></td></tr>
-        <tr><td>text (primary subtle)</td><td><code>semantic.color.primary.text</code></td><td><code>--ds-brand-content-default</code></td></tr>
+        <tr><td>bg (primary solid)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>text (primary solid)</td><td><code>semantic.brand.content.contrast</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
+        <tr><td>bg (primary subtle)</td><td><code>semantic.brand.subtle</code></td><td><code>--ds-brand-subtle</code></td></tr>
+        <tr><td>text (primary subtle)</td><td><code>semantic.brand.content.default</code></td><td><code>--ds-brand-content-default</code></td></tr>
         <tr><td>border-radius</td><td><code>foundation.radius.full</code></td><td><code>--ds-radius-full</code></td></tr>
       </tbody>
     </table>

--- a/docs/brand-principles.html
+++ b/docs/brand-principles.html
@@ -136,21 +136,21 @@ Cada princípio deve ser acionável: alguém deve conseguir olhar para um compon
 </thead>
 <tbody><tr>
 <td>Primary</td>
-<td><code>foundation.color.brand.primary</code></td>
+<td><code>foundation.brand.primary</code></td>
 <td>[hex]</td>
 <td>CTA, links, foco</td>
 </tr>
 <tr>
 <td>Secondary</td>
-<td><code>foundation.color.brand.secondary</code></td>
+<td><code>foundation.brand.secondary</code></td>
 <td>[hex]</td>
 <td>Complementar, destaques</td>
 </tr>
 <tr>
-<td>Accent</td>
-<td><code>foundation.color.brand.accent</code></td>
-<td>[hex]</td>
-<td>Ilustrações, detalhes</td>
+<td><del>Accent</del></td>
+<td><em>(não definido — foundation só tem <code>primary</code>/<code>secondary</code>. Se precisar de 3ª cor, criar em ADR)</em></td>
+<td>—</td>
+<td>—</td>
 </tr>
 </tbody></table>
 <h3>Tipografia</h3>

--- a/docs/brand-principles.md
+++ b/docs/brand-principles.md
@@ -50,9 +50,9 @@
 ### Cores da marca
 | Role | Token | Valor | Uso |
 |------|-------|-------|-----|
-| Primary | `foundation.color.brand.primary` | [hex] | CTA, links, foco |
-| Secondary | `foundation.color.brand.secondary` | [hex] | Complementar, destaques |
-| Accent | `foundation.color.brand.accent` | [hex] | Ilustrações, detalhes |
+| Primary | `foundation.brand.primary` | [hex] | CTA, links, foco |
+| Secondary | `foundation.brand.secondary` | [hex] | Complementar, destaques |
+| ~~Accent~~ | *(não definido — foundation só tem `primary`/`secondary`. Se precisar de 3ª cor, criar em ADR)* | — | — |
 
 ### Tipografia
 | Role | Font | Fallback | Uso |

--- a/docs/breadcrumb.html
+++ b/docs/breadcrumb.html
@@ -294,10 +294,10 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">cor do link</span><span data-lang="en">link color</span></td><td><code>semantic.text.link.default</code></td><td><code>--ds-content-link-default</code></td></tr>
-        <tr><td><span data-lang="pt">link hover</span><span data-lang="en">link hover</span></td><td><code>semantic.text.link.hover</code></td><td><code>--ds-content-link-hover</code></td></tr>
-        <tr><td><span data-lang="pt">texto atual</span><span data-lang="en">current text</span></td><td><code>semantic.text.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
-        <tr><td><span data-lang="pt">separador</span><span data-lang="en">separator</span></td><td><code>semantic.text.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
+        <tr><td><span data-lang="pt">cor do link</span><span data-lang="en">link color</span></td><td><code>semantic.content.link.default</code></td><td><code>--ds-content-link-default</code></td></tr>
+        <tr><td><span data-lang="pt">link hover</span><span data-lang="en">link hover</span></td><td><code>semantic.content.link.hover</code></td><td><code>--ds-content-link-hover</code></td></tr>
+        <tr><td><span data-lang="pt">texto atual</span><span data-lang="en">current text</span></td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
+        <tr><td><span data-lang="pt">separador</span><span data-lang="en">separator</span></td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/button.html
+++ b/docs/button.html
@@ -246,9 +246,9 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Estado</span><span data-lang="en">State</span></th><th>CSS trigger</th><th><span data-lang="pt">Mudança visual</span><span data-lang="en">Visual change</span></th><th>Token</th></tr></thead>
       <tbody>
-        <tr><td>Default</td><td>—</td><td><span data-lang="pt">Preenchimento primário</span><span data-lang="en">Primary fill</span></td><td><code>semantic.color.primary.default</code></td></tr>
-        <tr><td>Hover</td><td><code>:hover</code></td><td><span data-lang="pt">Preenchimento mais escuro</span><span data-lang="en">Darker fill</span></td><td><code>semantic.color.primary.hover</code></td></tr>
-        <tr><td>Pressed</td><td><code>:active</code></td><td><span data-lang="pt">Preenchimento mais escuro ainda</span><span data-lang="en">Darkest fill</span></td><td><code>semantic.color.primary.active</code></td></tr>
+        <tr><td>Default</td><td>—</td><td><span data-lang="pt">Preenchimento primário</span><span data-lang="en">Primary fill</span></td><td><code>semantic.brand.default</code></td></tr>
+        <tr><td>Hover</td><td><code>:hover</code></td><td><span data-lang="pt">Preenchimento mais escuro</span><span data-lang="en">Darker fill</span></td><td><code>semantic.brand.hover</code></td></tr>
+        <tr><td>Pressed</td><td><code>:active</code></td><td><span data-lang="pt">Preenchimento mais escuro ainda</span><span data-lang="en">Darkest fill</span></td><td><code>semantic.brand.active</code></td></tr>
         <tr><td>Focused</td><td><code>:focus-visible</code></td><td><span data-lang="pt">Anel de 2px, offset de 2px</span><span data-lang="en">2px outline ring, 2px offset</span></td><td><code>semantic.focus.ring.*</code></td></tr>
         <tr><td>Disabled</td><td><code>[disabled]</code></td><td><span data-lang="pt">Bg + fg atenuados, sem pointer events</span><span data-lang="en">Muted bg + fg, no pointer events</span></td><td><code>semantic.state.disabled.*</code></td></tr>
       </tbody>
@@ -421,12 +421,12 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td>background (default)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td>background (hover)</td><td><code>semantic.color.primary.hover</code></td><td><code>--ds-brand-hover</code></td></tr>
-        <tr><td>background (active)</td><td><code>semantic.color.primary.active</code></td><td><code>--ds-brand-active</code></td></tr>
+        <tr><td>background (default)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>background (hover)</td><td><code>semantic.brand.hover</code></td><td><code>--ds-brand-hover</code></td></tr>
+        <tr><td>background (active)</td><td><code>semantic.brand.active</code></td><td><code>--ds-brand-active</code></td></tr>
         <tr><td>background (disabled)</td><td><code>semantic.state.disabled.background</code></td><td><code>--ds-state-disabled-background</code></td></tr>
-        <tr><td>text/icon color</td><td><code>semantic.color.primary.foreground</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
-        <tr><td>text (disabled)</td><td><code>semantic.state.disabled.foreground</code></td><td><code>--ds-content-disabled</code></td></tr>
+        <tr><td>text/icon color</td><td><code>semantic.brand.content.contrast</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
+        <tr><td>text (disabled)</td><td><code>semantic.content.disabled</code></td><td><code>--ds-content-disabled</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-component</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>height (sm)</td><td><code>semantic.size.control.sm</code></td><td><code>--ds-size-control-sm</code></td></tr>
@@ -439,9 +439,9 @@
         <tr><td>padding-y (md)</td><td><code>semantic.space.control.padding-y.md</code></td><td><code>--ds-space-control-padding-y-md</code> (10px)</td></tr>
         <tr><td>padding-y (lg)</td><td><code>semantic.space.control.padding-y.lg</code></td><td><code>--ds-space-control-padding-y-lg</code> (12px)</td></tr>
         <tr><td>gap (icon ↔ label)</td><td><code>semantic.space.gap.sm</code></td><td><code>--ds-space-gap-sm</code></td></tr>
-        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-typography-control-font-size-sm</code></td></tr>
-        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-typography-control-font-size-md</code></td></tr>
-        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-typography-control-font-size-lg</code></td></tr>
+        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-control-font-size-sm</code></td></tr>
+        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-control-font-size-md</code></td></tr>
+        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-control-font-size-lg</code></td></tr>
         <tr><td>icon-size (sm)</td><td><code>semantic.size.control.icon.sm</code></td><td><code>--ds-size-control-icon-sm</code></td></tr>
         <tr><td>icon-size (md)</td><td><code>semantic.size.control.icon.md</code></td><td><code>--ds-size-control-icon-md</code></td></tr>
         <tr><td>icon-size (lg)</td><td><code>semantic.size.control.icon.lg</code></td><td><code>--ds-size-control-icon-lg</code></td></tr>

--- a/docs/card.html
+++ b/docs/card.html
@@ -357,7 +357,7 @@
         <tr><td>background</td><td><code>semantic.surface.default</code></td><td><code>--ds-surface-default</code></td></tr>
         <tr><td>border (outlined)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
         <tr><td>shadow (elevated)</td><td><code>foundation.shadow.sm</code></td><td><code>--ds-shadow-sm</code></td></tr>
-        <tr><td>border-radius</td><td><code>semantic.radius.lg</code></td><td><code>--ds-radius-lg</code></td></tr>
+        <tr><td>border-radius</td><td><code>foundation.radius.lg</code></td><td><code>--ds-radius-lg</code></td></tr>
         <tr><td>padding</td><td><code>semantic.space.inset.lg</code></td><td><code>--ds-space-inset-lg</code></td></tr>
       </tbody>
     </table>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,44 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.14]</h2>
+<h3>Corrigido</h3>
+<p>Audit da camada Component (19 docs HTML de componentes + meta-docs) revelou <strong>49 paths token inválidos + 14 CSS vars fantasmas</strong> — todos decorrentes de naming pré-ADR-011 (renames que a camada de dados incorporou mas a doc não). Corrigido em massa:</p>
+<ul>
+<li><strong><code>semantic.color.primary.*</code> → <code>semantic.brand.*</code></strong> (ADR-011): 15+ ocorrências em avatar, badge, button, checkbox, radio, spinner, tabs, textarea, toggle, etc. Incluindo sub-renames:<ul>
+<li><code>.primary.foreground</code> → <code>.brand.content.contrast</code></li>
+<li><code>.primary.text</code> → <code>.brand.content.default</code></li>
+</ul>
+</li>
+<li><strong><code>semantic.text.*</code> → <code>semantic.content.*</code></strong> (ADR-011): em breadcrumb, button, form-field, input, select, tabs, textarea, token-architecture. Inclui <code>.text.link.*</code> → <code>.content.link.*</code>.</li>
+<li><strong><code>semantic.state.disabled.foreground</code> → <code>semantic.content.disabled</code></strong> (ADR-011): button, select.</li>
+<li><strong><code>semantic.feedback.*.foreground|text</code> → <code>semantic.feedback.*.content.default</code></strong>: alert, textarea, form-field.</li>
+<li><strong><code>semantic.border.hover</code> → <code>semantic.border.control.hover</code></strong> (ADR-009): select, textarea.</li>
+<li><strong><code>semantic.radius.*</code> → <code>foundation.radius.*</code></strong> (radius é Foundation, não Semantic): card, checkbox, modal, radio, skeleton, tooltip.</li>
+<li><strong><code>foundation.z-index.*</code> → <code>foundation.z.*</code></strong>: modal, tooltip.</li>
+<li><strong><code>foundation.motion.duration.*</code> → <code>foundation.duration.*</code></strong>: spinner.</li>
+<li><strong><code>semantic.background.muted</code> → <code>semantic.state.disabled.background</code></strong>: skeleton.</li>
+<li><strong><code>--ds-typography-control-font-size-*</code> → <code>--ds-control-font-size-*</code></strong>: button, input, select, textarea. O Style Dictionary faz strip-layer removendo <code>typography</code>; a doc mantinha o nome pre-strip.</li>
+<li><strong><code>--ds-border-hover</code> → <code>--ds-border-control-hover</code></strong>: select, textarea.</li>
+</ul>
+<p>Também em <code>docs/token-architecture.html</code>: exemplo de component token atualizado de <code>--ds-button-bg-brand-default</code> (inexistente) para <code>--ds-button-background-toned-default</code> (real, criado no PR #18).</p>
+<p>E em <code>docs/brand-principles.md</code>: <code>foundation.color.brand.primary/secondary/accent</code> → <code>foundation.brand.primary/secondary</code> (<code>.accent</code> nunca existiu — só primary e secondary em Foundation; marcado como &quot;não definido&quot; até virar ADR).</p>
+<p><strong>Total: 66 renames em 19 arquivos.</strong> Audit residual: 2 &quot;fantasmas&quot; remanescentes são bad examples didáticos intencionais (<code>--ds-red-600</code> em <code>design-principles.html</code> dizendo &quot;não use&quot; + <code>--ds-color-primary</code> em <code>token-architecture.html</code> dizendo &quot;não colapse&quot;). Ficam.</p>
+<h3>Observações do audit (não aplicadas nesta PR)</h3>
+<p><strong>Semantic: 18 tokens órfãos</strong> (declarados mas nenhum componente consome): 3 border-widths extras, 5 <code>space-inset-*</code>, 6 <code>space-component-*</code>, 4 <code>space-section-*</code>. Decisão pendente (remover / manter / caso a caso).</p>
+<p><strong>Component: 19 tokens órfãos</strong> declarados no JSON mas não consumidos pelo CSS do próprio componente:</p>
+<ul>
+<li><code>button</code> (6): <code>background/foreground-toned-*</code> (criados no PR #18, CSS ainda usa semantic direto — refatoração pendente)</li>
+<li><code>checkbox</code> (6): <code>check-width/height-sm/md/lg</code> (CSS provavelmente desenha via SVG/stroke, não consome)</li>
+<li><code>input</code>, <code>select</code> (3 cada): <code>padding-y-sm/md/lg</code> (CSS usa height pra controlar Y, não padding-y)</li>
+<li><code>modal</code> (1): <code>padding</code></li>
+</ul>
+<h3>Notas</h3>
+<ul>
+<li>Audit confirmou: <strong>11 componentes têm tokens JSON</strong>, <strong>7 não têm e consomem semantic direto</strong> (alert, badge, breadcrumb, card, divider, tabs, tooltip — arquiteturalmente OK pela ADR-001: camada component é opcional).</li>
+<li><strong>Paridade light/dark: perfeita</strong> (132 = 132, 0 divergência de tipo).</li>
+<li>Próximo passo: decisão sobre os 37 órfãos totais (18 semantic + 19 component) + audit da camada Foundation.</li>
+</ul>
 <h2>[0.5.13]</h2>
 <h3>Corrigido</h3>
 <p>Audit completo dos 9 arquivos <code>foundations-*.html</code> restantes (após PR #19 auto-gerar <code>theme-colors</code>). Descobertos 3 arquivos com drift real:</p>

--- a/docs/checkbox.html
+++ b/docs/checkbox.html
@@ -418,11 +418,11 @@
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>border (unchecked)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
-        <tr><td>background (checked)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td>checkmark color</td><td><code>semantic.color.primary.foreground</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
+        <tr><td>background (checked)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>checkmark color</td><td><code>semantic.brand.content.contrast</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.border</code></td><td><code>--ds-feedback-error-border</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
-        <tr><td>border-radius</td><td><code>semantic.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
+        <tr><td>border-radius</td><td><code>foundation.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.13**
+> Versão atual: **0.5.14**
 
 ## Status geral
 

--- a/docs/form-field.html
+++ b/docs/form-field.html
@@ -544,10 +544,10 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">cor do label</span><span data-lang="en">label color</span></td><td><code>semantic.text.default</code></td><td><code>--ds-content-default</code></td></tr>
-        <tr><td><span data-lang="pt">cor do obrigatorio</span><span data-lang="en">required color</span></td><td><code>semantic.feedback.error.text</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
-        <tr><td><span data-lang="pt">cor do auxiliar</span><span data-lang="en">helper color</span></td><td><code>semantic.text.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
-        <tr><td><span data-lang="pt">cor do erro</span><span data-lang="en">error color</span></td><td><code>semantic.feedback.error.text</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
+        <tr><td><span data-lang="pt">cor do label</span><span data-lang="en">label color</span></td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td><span data-lang="pt">cor do obrigatorio</span><span data-lang="en">required color</span></td><td><code>semantic.feedback.error.content.default</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
+        <tr><td><span data-lang="pt">cor do auxiliar</span><span data-lang="en">helper color</span></td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
+        <tr><td><span data-lang="pt">cor do erro</span><span data-lang="en">error color</span></td><td><code>semantic.feedback.error.content.default</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
         <tr><td><span data-lang="pt">espaçamento (label para input)</span><span data-lang="en">spacing (label to input)</span></td><td><code>semantic.space.gap.xs</code></td><td><code>--ds-space-gap-xs</code></td></tr>
         <tr><td><span data-lang="pt">espaçamento (input para auxiliar)</span><span data-lang="en">spacing (input to helper)</span></td><td><code>semantic.space.gap.xs</code></td><td><code>--ds-space-gap-xs</code></td></tr>
       </tbody>

--- a/docs/input.html
+++ b/docs/input.html
@@ -571,9 +571,9 @@
         <tr><td>border-color (default)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
         <tr><td>border-color (focus)</td><td><code>semantic.border.focus</code></td><td><code>--ds-border-focus</code></td></tr>
         <tr><td>border-color (error)</td><td><code>semantic.feedback.error.border</code></td><td><code>--ds-feedback-error-border</code></td></tr>
-        <tr><td>text color</td><td><code>semantic.text.default</code></td><td><code>--ds-content-default</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.text.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
-        <tr><td>icon color</td><td><code>semantic.text.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
+        <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
+        <tr><td>icon color</td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-component</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>height (sm)</td><td><code>semantic.size.control.sm</code></td><td><code>--ds-size-control-sm</code> (32px)</td></tr>
@@ -582,9 +582,9 @@
         <tr><td>padding-x (sm)</td><td><code>semantic.space.control.padding-x.sm</code></td><td><code>--ds-space-control-padding-x-sm</code></td></tr>
         <tr><td>padding-x (md)</td><td><code>semantic.space.control.padding-x.md</code></td><td><code>--ds-space-control-padding-x-md</code></td></tr>
         <tr><td>padding-x (lg)</td><td><code>semantic.space.control.padding-x.lg</code></td><td><code>--ds-space-control-padding-x-lg</code></td></tr>
-        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-typography-control-font-size-sm</code></td></tr>
-        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-typography-control-font-size-md</code></td></tr>
-        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-typography-control-font-size-lg</code></td></tr>
+        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-control-font-size-sm</code></td></tr>
+        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-control-font-size-md</code></td></tr>
+        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-control-font-size-lg</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.5.13. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.5.14. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -311,6 +311,46 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em `docs/process-versioning.html`.
 
 ## [Não publicado]
+
+## [0.5.14]
+
+### Corrigido
+Audit da camada Component (19 docs HTML de componentes + meta-docs) revelou **49 paths token inválidos + 14 CSS vars fantasmas** — todos decorrentes de naming pré-ADR-011 (renames que a camada de dados incorporou mas a doc não). Corrigido em massa:
+
+- **`semantic.color.primary.*` → `semantic.brand.*`** (ADR-011): 15+ ocorrências em avatar, badge, button, checkbox, radio, spinner, tabs, textarea, toggle, etc. Incluindo sub-renames:
+  - `.primary.foreground` → `.brand.content.contrast`
+  - `.primary.text` → `.brand.content.default`
+- **`semantic.text.*` → `semantic.content.*`** (ADR-011): em breadcrumb, button, form-field, input, select, tabs, textarea, token-architecture. Inclui `.text.link.*` → `.content.link.*`.
+- **`semantic.state.disabled.foreground` → `semantic.content.disabled`** (ADR-011): button, select.
+- **`semantic.feedback.*.foreground|text` → `semantic.feedback.*.content.default`**: alert, textarea, form-field.
+- **`semantic.border.hover` → `semantic.border.control.hover`** (ADR-009): select, textarea.
+- **`semantic.radius.*` → `foundation.radius.*`** (radius é Foundation, não Semantic): card, checkbox, modal, radio, skeleton, tooltip.
+- **`foundation.z-index.*` → `foundation.z.*`**: modal, tooltip.
+- **`foundation.motion.duration.*` → `foundation.duration.*`**: spinner.
+- **`semantic.background.muted` → `semantic.state.disabled.background`**: skeleton.
+- **`--ds-typography-control-font-size-*` → `--ds-control-font-size-*`**: button, input, select, textarea. O Style Dictionary faz strip-layer removendo `typography`; a doc mantinha o nome pre-strip.
+- **`--ds-border-hover` → `--ds-border-control-hover`**: select, textarea.
+
+Também em `docs/token-architecture.html`: exemplo de component token atualizado de `--ds-button-bg-brand-default` (inexistente) para `--ds-button-background-toned-default` (real, criado no PR #18).
+
+E em `docs/brand-principles.md`: `foundation.color.brand.primary/secondary/accent` → `foundation.brand.primary/secondary` (`.accent` nunca existiu — só primary e secondary em Foundation; marcado como "não definido" até virar ADR).
+
+**Total: 66 renames em 19 arquivos.** Audit residual: 2 "fantasmas" remanescentes são bad examples didáticos intencionais (`--ds-red-600` em `design-principles.html` dizendo "não use" + `--ds-color-primary` em `token-architecture.html` dizendo "não colapse"). Ficam.
+
+### Observações do audit (não aplicadas nesta PR)
+
+**Semantic: 18 tokens órfãos** (declarados mas nenhum componente consome): 3 border-widths extras, 5 `space-inset-*`, 6 `space-component-*`, 4 `space-section-*`. Decisão pendente (remover / manter / caso a caso).
+
+**Component: 19 tokens órfãos** declarados no JSON mas não consumidos pelo CSS do próprio componente:
+- `button` (6): `background/foreground-toned-*` (criados no PR #18, CSS ainda usa semantic direto — refatoração pendente)
+- `checkbox` (6): `check-width/height-sm/md/lg` (CSS provavelmente desenha via SVG/stroke, não consome)
+- `input`, `select` (3 cada): `padding-y-sm/md/lg` (CSS usa height pra controlar Y, não padding-y)
+- `modal` (1): `padding`
+
+### Notas
+- Audit confirmou: **11 componentes têm tokens JSON**, **7 não têm e consomem semantic direto** (alert, badge, breadcrumb, card, divider, tabs, tooltip — arquiteturalmente OK pela ADR-001: camada component é opcional).
+- **Paridade light/dark: perfeita** (132 = 132, 0 divergência de tipo).
+- Próximo passo: decisão sobre os 37 órfãos totais (18 semantic + 19 component) + audit da camada Foundation.
 
 ## [0.5.13]
 
@@ -730,9 +770,9 @@ Hoje o script loga e pede intervenção quando encontra ambiguidade (ex: variáv
 ### Cores da marca
 | Role | Token | Valor | Uso |
 |------|-------|-------|-----|
-| Primary | `foundation.color.brand.primary` | [hex] | CTA, links, foco |
-| Secondary | `foundation.color.brand.secondary` | [hex] | Complementar, destaques |
-| Accent | `foundation.color.brand.accent` | [hex] | Ilustrações, detalhes |
+| Primary | `foundation.brand.primary` | [hex] | CTA, links, foco |
+| Secondary | `foundation.brand.secondary` | [hex] | Complementar, destaques |
+| ~~Accent~~ | *(não definido — foundation só tem `primary`/`secondary`. Se precisar de 3ª cor, criar em ADR)* | — | — |
 
 ### Tipografia
 | Role | Font | Fallback | Uso |
@@ -767,7 +807,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.13**
+> Versão atual: **0.5.14**
 
 ## Status geral
 
@@ -1379,13 +1419,13 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.13**
+> Versão atual: **0.5.14**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.13 |
+| Versão | 0.5.14 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -2819,6 +2859,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T21:09:13.744Z
-Versão: 0.5.13
+Gerado por scripts/build-llms.mjs em 2026-04-21T21:30:08.207Z
+Versão: 0.5.14
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.13. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.14. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -89,4 +89,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T21:09:13.744Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T21:30:08.207Z.

--- a/docs/modal.html
+++ b/docs/modal.html
@@ -398,9 +398,9 @@
         <tr><td>overlay background</td><td><code>semantic.overlay.default</code></td><td><code>--ds-overlay-default</code></td></tr>
         <tr><td>surface</td><td><code>semantic.surface.elevated</code></td><td><code>--ds-surface-elevated</code></td></tr>
         <tr><td>shadow</td><td><code>foundation.shadow.xl</code></td><td><code>--ds-shadow-xl</code></td></tr>
-        <tr><td>z-index (overlay)</td><td><code>foundation.z-index.30</code></td><td><code>--ds-z-30</code></td></tr>
-        <tr><td>z-index (modal)</td><td><code>foundation.z-index.40</code></td><td><code>--ds-z-40</code></td></tr>
-        <tr><td>border-radius</td><td><code>semantic.radius.lg</code></td><td><code>--ds-radius-lg</code></td></tr>
+        <tr><td>z-index (overlay)</td><td><code>foundation.z.30</code></td><td><code>--ds-z-30</code></td></tr>
+        <tr><td>z-index (modal)</td><td><code>foundation.z.40</code></td><td><code>--ds-z-40</code></td></tr>
+        <tr><td>border-radius</td><td><code>foundation.radius.lg</code></td><td><code>--ds-radius-lg</code></td></tr>
         <tr><td>padding</td><td><code>semantic.space.inset.lg</code></td><td><code>--ds-space-inset-lg</code></td></tr>
       </tbody>
     </table>

--- a/docs/radio.html
+++ b/docs/radio.html
@@ -402,14 +402,14 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <p style="margin-bottom:var(--ds-spacing-4);color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);">
-      <span data-lang="pt">Mesmos tokens do Checkbox exceto <code>border-radius: 50%</code> (círculo) em vez de <code>semantic.radius.sm</code>.</span><span data-lang="en">Same tokens as Checkbox except <code>border-radius: 50%</code> (circle) instead of <code>semantic.radius.sm</code>.</span>
+      <span data-lang="pt">Mesmos tokens do Checkbox exceto <code>border-radius: 50%</code> (círculo) em vez de <code>foundation.radius.sm</code>.</span><span data-lang="en">Same tokens as Checkbox except <code>border-radius: 50%</code> (circle) instead of <code>foundation.radius.sm</code>.</span>
     </p>
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>border (unselected)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
-        <tr><td>background (selected)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td>dot color</td><td><code>semantic.color.primary.foreground</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
+        <tr><td>background (selected)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>dot color</td><td><code>semantic.brand.content.contrast</code></td><td><code>--ds-brand-content-contrast</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.border</code></td><td><code>--ds-feedback-error-border</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>border-radius</td><td>50% (circle)</td><td><code>border-radius: 50%</code></td></tr>

--- a/docs/select.html
+++ b/docs/select.html
@@ -390,7 +390,7 @@
       <thead><tr><th>State</th><th>CSS trigger</th><th>Visual change</th><th>Token</th></tr></thead>
       <tbody>
         <tr><td>Default</td><td>---</td><td>Neutral border</td><td><code>semantic.border.default</code></td></tr>
-        <tr><td>Hover</td><td><code>:hover</code></td><td>Darker border</td><td><code>semantic.border.hover</code></td></tr>
+        <tr><td>Hover</td><td><code>:hover</code></td><td>Darker border</td><td><code>semantic.border.control.hover</code></td></tr>
         <tr><td>Focused</td><td><code>:focus-visible</code></td><td>2px outline ring, 2px offset</td><td><code>semantic.focus.ring.*</code></td></tr>
         <tr><td>Error</td><td><code>.ds-select--error</code></td><td>Red border</td><td><code>semantic.feedback.error.default</code></td></tr>
         <tr><td>Disabled</td><td><code>[disabled]</code></td><td>Muted bg + fg, no pointer events</td><td><code>semantic.state.disabled.*</code></td></tr>
@@ -502,13 +502,13 @@
       <tbody>
         <tr><td>background</td><td><code>semantic.surface.default</code></td><td><code>--ds-surface-default</code></td></tr>
         <tr><td>border (default)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
-        <tr><td>border (hover)</td><td><code>semantic.border.hover</code></td><td><code>--ds-border-hover</code></td></tr>
+        <tr><td>border (hover)</td><td><code>semantic.border.control.hover</code></td><td><code>--ds-border-control-hover</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.default</code></td><td><code>--ds-feedback-error-default</code></td></tr>
-        <tr><td>text color</td><td><code>semantic.text.default</code></td><td><code>--ds-content-default</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.text.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
+        <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
         <tr><td>arrow color</td><td>Inherits via <code>currentColor</code></td><td>---</td></tr>
         <tr><td>background (disabled)</td><td><code>semantic.state.disabled.background</code></td><td><code>--ds-state-disabled-background</code></td></tr>
-        <tr><td>text (disabled)</td><td><code>semantic.state.disabled.foreground</code></td><td><code>--ds-content-disabled</code></td></tr>
+        <tr><td>text (disabled)</td><td><code>semantic.content.disabled</code></td><td><code>--ds-content-disabled</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-component</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>height (sm)</td><td><code>semantic.size.control.sm</code></td><td><code>--ds-size-control-sm</code> (32px)</td></tr>
@@ -517,9 +517,9 @@
         <tr><td>padding-x (sm)</td><td><code>semantic.space.control.padding-x.sm</code></td><td><code>--ds-space-control-padding-x-sm</code></td></tr>
         <tr><td>padding-x (md)</td><td><code>semantic.space.control.padding-x.md</code></td><td><code>--ds-space-control-padding-x-md</code></td></tr>
         <tr><td>padding-x (lg)</td><td><code>semantic.space.control.padding-x.lg</code></td><td><code>--ds-space-control-padding-x-lg</code></td></tr>
-        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-typography-control-font-size-sm</code></td></tr>
-        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-typography-control-font-size-md</code></td></tr>
-        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-typography-control-font-size-lg</code></td></tr>
+        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-control-font-size-sm</code></td></tr>
+        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-control-font-size-md</code></td></tr>
+        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-control-font-size-lg</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/skeleton.html
+++ b/docs/skeleton.html
@@ -303,9 +303,9 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">fundo</span><span data-lang="en">background</span></td><td><code>semantic.background.muted</code></td><td><code>--ds-state-disabled-background</code></td></tr>
+        <tr><td><span data-lang="pt">fundo</span><span data-lang="en">background</span></td><td><code>semantic.state.disabled.background</code></td><td><code>--ds-state-disabled-background</code></td></tr>
         <tr><td><span data-lang="pt">animação (pulso de opacidade)</span><span data-lang="en">animation (opacity pulse)</span></td><td><code>opacity range</code></td><td><code>--ds-opacity-25</code> to <code>--ds-opacity-50</code></td></tr>
-        <tr><td><span data-lang="pt">radius (texto)</span><span data-lang="en">radius (text)</span></td><td><code>semantic.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
+        <tr><td><span data-lang="pt">radius (texto)</span><span data-lang="en">radius (text)</span></td><td><code>foundation.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
         <tr><td><span data-lang="pt">radius (circulo)</span><span data-lang="en">radius (circle)</span></td><td><code>foundation.radius.full</code></td><td><code>--ds-radius-full</code></td></tr>
       </tbody>
     </table>

--- a/docs/spinner.html
+++ b/docs/spinner.html
@@ -256,8 +256,8 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">cor</span><span data-lang="en">color</span></td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td><span data-lang="pt">duração da animação</span><span data-lang="en">animation duration</span></td><td><code>foundation.motion.duration.slow</code></td><td><code>--ds-duration-slow</code></td></tr>
+        <tr><td><span data-lang="pt">cor</span><span data-lang="en">color</span></td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td><span data-lang="pt">duração da animação</span><span data-lang="en">animation duration</span></td><td><code>foundation.duration.slow</code></td><td><code>--ds-duration-slow</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -292,9 +292,9 @@
     <table class="ds-token-table">
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
-        <tr><td><span data-lang="pt">texto (inativo)</span><span data-lang="en">text (inactive)</span></td><td><code>semantic.text.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
-        <tr><td><span data-lang="pt">texto (ativo)</span><span data-lang="en">text (active)</span></td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
-        <tr><td><span data-lang="pt">indicador ativo</span><span data-lang="en">active indicator</span></td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td><span data-lang="pt">texto (inativo)</span><span data-lang="en">text (inactive)</span></td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-secondary</code></td></tr>
+        <tr><td><span data-lang="pt">texto (ativo)</span><span data-lang="en">text (active)</span></td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td><span data-lang="pt">indicador ativo</span><span data-lang="en">active indicator</span></td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
         <tr><td><span data-lang="pt">fundo (hover)</span><span data-lang="en">background (hover)</span></td><td><code>semantic.state.hover</code></td><td><code>--ds-state-hover</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
       </tbody>

--- a/docs/textarea.html
+++ b/docs/textarea.html
@@ -424,25 +424,25 @@
       <tbody>
         <tr><td>background</td><td><code>semantic.surface.default</code></td><td><code>--ds-surface-default</code></td></tr>
         <tr><td>border</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
-        <tr><td>border (hover)</td><td><code>semantic.border.hover</code></td><td><code>--ds-border-hover</code></td></tr>
-        <tr><td>border (focus)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>border (hover)</td><td><code>semantic.border.control.hover</code></td><td><code>--ds-border-control-hover</code></td></tr>
+        <tr><td>border (focus)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.default</code></td><td><code>--ds-feedback-error-default</code></td></tr>
-        <tr><td>text color</td><td><code>semantic.text.default</code></td><td><code>--ds-content-default</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.text.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
+        <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-component</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>padding-x (sm/md/lg)</td><td><code>semantic.space.control.padding-x.*</code></td><td><code>--ds-space-control-padding-x-sm/md/lg</code></td></tr>
         <tr><td>padding-y (sm)</td><td><code>semantic.space.control.padding-y.sm</code></td><td><code>--ds-space-control-padding-y-sm</code> (8px)</td></tr>
         <tr><td>padding-y (md)</td><td><code>semantic.space.control.padding-y.md</code></td><td><code>--ds-space-control-padding-y-md</code> (10px, was 12px)</td></tr>
         <tr><td>padding-y (lg)</td><td><code>semantic.space.control.padding-y.lg</code></td><td><code>--ds-space-control-padding-y-lg</code> (12px, was 16px)</td></tr>
-        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-typography-control-font-size-sm</code></td></tr>
-        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-typography-control-font-size-md</code></td></tr>
-        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-typography-control-font-size-lg</code></td></tr>
+        <tr><td>font-size (sm)</td><td><code>semantic.typography.control.font-size.sm</code></td><td><code>--ds-control-font-size-sm</code></td></tr>
+        <tr><td>font-size (md)</td><td><code>semantic.typography.control.font-size.md</code></td><td><code>--ds-control-font-size-md</code></td></tr>
+        <tr><td>font-size (lg)</td><td><code>semantic.typography.control.font-size.lg</code></td><td><code>--ds-control-font-size-lg</code></td></tr>
         <tr><td>min-height (sm)</td><td>--</td><td><code>80px</code></td></tr>
         <tr><td>min-height (md)</td><td>--</td><td><code>120px</code></td></tr>
         <tr><td>min-height (lg)</td><td>--</td><td><code>160px</code></td></tr>
-        <tr><td>counter color</td><td><code>semantic.text.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
-        <tr><td>counter color (over)</td><td><code>semantic.feedback.error.text</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
+        <tr><td>counter color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-tertiary</code></td></tr>
+        <tr><td>counter color (over)</td><td><code>semantic.feedback.error.content.default</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
       </tbody>
     </table>
     <p style="margin-top:var(--ds-spacing-2);color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);">

--- a/docs/toggle.html
+++ b/docs/toggle.html
@@ -352,7 +352,7 @@
       <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>track (off)</td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
-        <tr><td>track (on)</td><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td></tr>
+        <tr><td>track (on)</td><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td></tr>
         <tr><td>thumb</td><td><code>semantic.surface.default</code></td><td><code>--ds-surface-default</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
       </tbody>

--- a/docs/token-architecture.html
+++ b/docs/token-architecture.html
@@ -99,9 +99,9 @@
         <div class="ds-arch__header ds-arch__header--sem">Semantic</div>
         <div class="ds-arch__body">
           <span data-lang="pt">Intenção e significado. Referencia foundation via aliases. Sensível a modo (light/dark).</span><span data-lang="en">Intent and meaning. References foundation via aliases. Mode-aware (light/dark).</span><br><br>
-          <code>semantic.color.primary.default</code> → <code>{foundation.brand.primary}</code><br>
-          <code>semantic.text.default</code> → <code>{foundation.color.neutral.900}</code> (light)<br>
-          <code>semantic.text.default</code> → <code>{foundation.color.neutral.50}</code> (dark)<br><br>
+          <code>semantic.brand.default</code> → <code>{foundation.brand.primary}</code><br>
+          <code>semantic.content.default</code> → <code>{foundation.color.neutral.900}</code> (light)<br>
+          <code>semantic.content.default</code> → <code>{foundation.color.neutral.50}</code> (dark)<br><br>
           <span data-lang="pt">~104 tokens × 2 modos.</span><span data-lang="en">~104 tokens × 2 modes.</span>
         </div>
       </div>
@@ -110,7 +110,7 @@
         <div class="ds-arch__header ds-arch__header--cmp">Component</div>
         <div class="ds-arch__body">
           <span data-lang="pt">Tokens por componente. Referencia semantic, nunca foundation.</span><span data-lang="en">Per-component tokens. References semantic, never foundation.</span><br><br>
-          <code>component.button.background.brand.default</code> → <code>{semantic.color.primary.default}</code><br>
+          <code>component.button.background.brand.default</code> → <code>{semantic.brand.default}</code><br>
           <code>component.button.padding.md</code> → <code>{semantic.space.inset.md}</code><br><br>
           <span data-lang="pt">118 tokens em 11 arquivos de componente.</span><span data-lang="en">118 tokens across 11 component files.</span>
         </div>
@@ -138,7 +138,7 @@
       </div>
       <div class="ds-chain__step">
         <span class="ds-chain__badge ds-chain__badge--sem">semantic</span>
-        <code>semantic.color.primary.default</code>
+        <code>semantic.brand.default</code>
       </div>
       <div class="ds-chain__step">
         <span style="width:54px;display:inline-block"></span>
@@ -182,7 +182,7 @@
 }</div>
 
     <p style="color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);">
-      <span data-lang="pt">Apenas <code>semantic.color.primary.default</code> referencia <code>foundation.brand.primary</code>. Todos os outros estados (hover, active, subtle) referenciam a paleta foundation diretamente, porque mudanças de estado precisam de steps específicos da paleta que não seguem uma fórmula.</span><span data-lang="en">Only <code>semantic.color.primary.default</code> references <code>foundation.brand.primary</code>. All other states (hover, active, subtle) reference the foundation palette directly, because state shifts need specific palette steps that don't follow a formula.</span>
+      <span data-lang="pt">Apenas <code>semantic.brand.default</code> referencia <code>foundation.brand.primary</code>. Todos os outros estados (hover, active, subtle) referenciam a paleta foundation diretamente, porque mudanças de estado precisam de steps específicos da paleta que não seguem uma fórmula.</span><span data-lang="en">Only <code>semantic.brand.default</code> references <code>foundation.brand.primary</code>. All other states (hover, active, subtle) reference the foundation palette directly, because state shifts need specific palette steps that don't follow a formula.</span>
     </p>
   </div>
 
@@ -205,7 +205,7 @@
 
     <div class="ds-callout ds-callout--warning">
       <div class="ds-callout__title"><span data-lang="pt">A regra do sufixo <code>-default</code></span><span data-lang="en">The <code>-default</code> suffix rule</span></div>
-      <span data-lang="pt">Todo token terminado em <code>.default</code> gera <code>-default</code> no CSS. Sem exceções, sem colapsar. <code>semantic.color.primary.default</code> vira <code>--ds-brand-default</code>, não <code>--ds-color-primary</code>.</span><span data-lang="en">Every token ending in <code>.default</code> generates <code>-default</code> in CSS. No exceptions, no collapsing. <code>semantic.color.primary.default</code> becomes <code>--ds-brand-default</code>, not <code>--ds-color-primary</code>.</span>
+      <span data-lang="pt">Todo token terminado em <code>.default</code> gera <code>-default</code> no CSS. Sem exceções, sem colapsar. <code>semantic.brand.default</code> vira <code>--ds-brand-default</code>, não <code>--ds-color-primary</code>.</span><span data-lang="en">Every token ending in <code>.default</code> generates <code>-default</code> in CSS. No exceptions, no collapsing. <code>semantic.brand.default</code> becomes <code>--ds-brand-default</code>, not <code>--ds-color-primary</code>.</span>
     </div>
   </div>
 
@@ -263,9 +263,9 @@
       <tbody>
         <tr><td><code>foundation.color.blue.500</code></td><td><code>--ds-color-blue-500</code></td><td><code>color/blue/500</code> (Foundation)</td></tr>
         <tr><td><code>foundation.brand.primary</code></td><td><code>--ds-brand-primary</code></td><td><code>brand/primary</code> (Brand)</td></tr>
-        <tr><td><code>semantic.color.primary.default</code></td><td><code>--ds-brand-default</code></td><td><code>color/primary/default</code> (Semantic)</td></tr>
+        <tr><td><code>semantic.brand.default</code></td><td><code>--ds-brand-default</code></td><td><code>color/primary/default</code> (Semantic)</td></tr>
         <tr><td><code>semantic.space.inset.md</code></td><td><code>--ds-space-inset-md</code></td><td><code>space/inset/md</code> (Semantic)</td></tr>
-        <tr><td><code>component.button.background.brand.default</code></td><td><code>--ds-button-bg-brand-default</code></td><td><code>button/background/brand/default</code> (Component)</td></tr>
+        <tr><td><code>component.button.background.toned.default</code></td><td><code>--ds-button-background-toned-default</code></td><td><code>button/background/toned/default</code> (Component)</td></tr>
       </tbody>
     </table>
     <p style="color:var(--ds-content-secondary);font-size:var(--ds-font-size-sm);">

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.13**
+> Versão atual: **0.5.14**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.13 |
+| Versão | 0.5.14 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,7 +63,7 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T21:09:13.975Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T21:30:08.435Z</div>
       <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>

--- a/docs/tooltip.html
+++ b/docs/tooltip.html
@@ -320,8 +320,8 @@
       <tbody>
         <tr><td><span data-lang="pt">fundo</span><span data-lang="en">background</span></td><td><code>neutral-900</code> (light mode)</td><td>---</td></tr>
         <tr><td><span data-lang="pt">texto</span><span data-lang="en">text</span></td><td><code>white</code> (light mode)</td><td>---</td></tr>
-        <tr><td>border-radius</td><td><code>semantic.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
-        <tr><td>z-index</td><td><code>foundation.z-index.20</code></td><td><code>--ds-z-20</code></td></tr>
+        <tr><td>border-radius</td><td><code>foundation.radius.sm</code></td><td><code>--ds-radius-sm</code></td></tr>
+        <tr><td>z-index</td><td><code>foundation.z.20</code></td><td><code>--ds-z-20</code></td></tr>
       </tbody>
     </table>
   </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.13 -->v0.5.13</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.14 -->v0.5.14</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",


### PR DESCRIPTION
## Summary

Audit cross-layer completo da camada Component (tokens JSON ↔ CSS ↔ docs HTML) revelou que **19 docs HTML usavam naming pré-ADR-011** — a camada de dados foi renomeada (ex: `semantic.color.primary.*` → `semantic.brand.*`), CSS foi regenerado, mas a doc não acompanhou. Resultado: 49 paths token inválidos + 14 CSS vars fantasmas.

## Correções aplicadas (66 renames em massa)

Principais padrões:

| De | Para | ADR |
|---|---|---|
| `semantic.color.primary.*` | `semantic.brand.*` | ADR-011 |
| `.primary.foreground` | `.brand.content.contrast` | ADR-011 |
| `.primary.text` | `.brand.content.default` | ADR-011 |
| `semantic.text.*` | `semantic.content.*` | ADR-011 |
| `semantic.state.disabled.foreground` | `semantic.content.disabled` | ADR-011 |
| `semantic.feedback.*.foreground\|text` | `.feedback.*.content.default` | ADR-011 |
| `semantic.border.hover` | `semantic.border.control.hover` | ADR-009 |
| `semantic.radius.*` | `foundation.radius.*` | radius é Foundation |
| `foundation.z-index.*` | `foundation.z.*` | — |
| `foundation.motion.duration.*` | `foundation.duration.*` | — |
| `--ds-typography-control-font-size-*` | `--ds-control-font-size-*` | Style Dictionary strip-layer |
| `--ds-border-hover` | `--ds-border-control-hover` | ADR-009 |

Plus fixes pontuais:
- `token-architecture.html`: exemplo `--ds-button-bg-brand-default` (inexistente) → `--ds-button-background-toned-default` (real, criado no PR #18).
- `brand-principles.md`: `foundation.color.brand.*` → `foundation.brand.*`; `.accent` removido (só `primary`/`secondary` existem — `.accent` nunca foi criado).

## Residual intencional

2 "fantasmas" ficam — são **bad examples didáticos**:
- `design-principles.html`: "não use `--ds-red-600`"
- `token-architecture.html`: "não colapse pra `--ds-color-primary`"

## Observações do audit (não aplicadas — decisão pendente)

### 37 tokens órfãos

**Semantic (18)**: declarados mas nenhum componente consome.
- 3 border-widths extras (`subtle/strong/focus` — só `default` é usado)
- 5 `space-inset-*` (componentes migraram pra `space-control-padding-*`)
- 6 `space-component-*` (todos)
- 4 `space-section-*` (todos)

**Component (19)**: declarados no JSON mas não consumidos pelo CSS do próprio componente.
- `button` (6): `background/foreground-toned-*` — criados no PR #18, CSS ainda usa semantic direto
- `checkbox` (6): `check-width/height` — CSS provavelmente desenha via SVG/stroke
- `input`, `select` (3 cada): `padding-y-*` — CSS controla Y por height
- `modal` (1): `padding`

Próximo PR: decidir remover/manter/caso-a-caso.

## Confirmações arquiteturais

- **Paridade light/dark**: 132 = 132, 0 divergências, 0 tipos conflitantes ✅
- **11 componentes têm tokens JSON**, 7 não têm (alert, badge, breadcrumb, card, divider, tabs, tooltip) — arquiteturalmente OK pela ADR-001 (camada component é opcional)

## Test plan

- [x] `npm run build:all` passa (0 avisos, 0 erros)
- [x] Audit: 49 paths inválidos → 0 reais (2 bad examples didáticos restantes)
- [x] Audit: 14 CSS fantasmas → 0 reais (1 bad example restante)
- [ ] Verificar visualmente no site pós-deploy que os componentes listam os tokens corretos

## Próximo

- [ ] Decisão sobre os 37 órfãos (Semantic + Component)
- [ ] Audit rápido da camada Foundation (JSON ↔ CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)