### PR TITLE
feat(tokens): ADR-012 + categoria BY_DESIGN no sync (0.5.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.16]
+
+### Adicionado
+- **ADR-012** — *Tokens de line-height e letter-spacing divergem por design entre Figma e JSON.* Formaliza que esses dois grupos de tokens são representados em unidades incompatíveis (PX no Figma vs ratio/rem/em no JSON) por limitação da Plugin API do Figma e requisito WCAG 1.4.4 do CSS. Os dois lados são canônicos em seus contextos de consumo; **não sincronizam entre si**.
+- **Categoria `BY_DESIGN`** no sync Figma → JSON. Listas `FIGMA_ONLY_PATHS` e `JSON_ONLY_PATHS` em `scripts/lib/figma-dtcg.mjs` reconhecem tokens que existem só de um lado por escolha documentada. Ficam em `BY_DESIGN` (informativo) em vez de falso-positivarem como `NEW_IN_FIGMA` ou `MISSING_IN_FIGMA`.
+
+### Corrigido (efeito do ADR-012 no sync)
+Antes: sync reportava **23 NEW_IN_FIGMA + 14 MISSING_IN_FIGMA** (37 falsos drifts) em line-height/letter-spacing, mascarando drifts reais.
+
+Depois: **0 NEW_IN_FIGMA + 0 MISSING_IN_FIGMA + 37 BY_DESIGN** (informativo). Dry-run sai com exit 0. Qualquer drift novo em typography (ex: valor real diferente em `semantic.brand.hover`) continua detectado.
+
+### Atualizado
+- `docs/process-figma-sync.md`: tabela de categorias passou de 4 pra 6 (inclui `CSS_ONLY` e `BY_DESIGN`, ambas marcadas como "não aplica em `--write`").
+- `scripts/sync-tokens-from-figma.mjs`: relatório inclui contagem e seção `BY_DESIGN` com indicação de lado (`figma-only` ou `json-only`).
+
+### Contexto operacional
+Issue #23 (origem) fica **fechada** com este PR. Questão de unificação futura via composite typography tokens fica em issue #27 (ADR-013 a abrir quando for priorizada).
+
 ## [0.5.15]
 
 ### Consolidado

--- a/docs/adr-index.md
+++ b/docs/adr-index.md
@@ -3,7 +3,7 @@
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
 
-11 decisões registradas.
+12 decisões registradas.
 
 | ADR | Título | Status | Data |
 |-----|--------|--------|------|
@@ -18,3 +18,4 @@
 | [ADR-009](decisions/ADR-009-border-control-vs-decorative.md) | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 | 2026-04-16 |
 | [ADR-010](decisions/ADR-010-abolir-white-black-puros.md) | Remoção de `foundation.color.white` e `foundation.color.black` puros | Aceita — Implementada em 0.5.0 | 2026-04-16 |
 | [ADR-011](decisions/ADR-011-renaming-tokens-semanticos-de-cor.md) | Reestruturação do naming de tokens semânticos de cor | Aceita — Implementada em 0.5.0 | 2026-04-17 |
+| [ADR-012](decisions/ADR-012-typography-tokens-divergence.md) | Tokens de line-height e letter-spacing divergem por design entre Figma e JSON | Aceita | 2026-04-21 |

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-04-21T22:52:18.896Z",
-  "version": "0.5.15",
-  "count": 11,
+  "generatedAt": "2026-04-21T23:19:17.419Z",
+  "version": "0.5.16",
+  "count": 12,
   "adrs": [
     {
       "id": "ADR-001",
@@ -101,6 +101,15 @@
       "date": "2026-04-17",
       "sourceFile": "docs/decisions/ADR-011-renaming-tokens-semanticos-de-cor.md",
       "url": "https://uxindesign.github.io/design-system-core/docs/decisions/adr-011-renaming-tokens-semanticos-de-cor.html"
+    },
+    {
+      "id": "ADR-012",
+      "num": 12,
+      "title": "Tokens de line-height e letter-spacing divergem por design entre Figma e JSON",
+      "status": "Aceita",
+      "date": "2026-04-21",
+      "sourceFile": "docs/decisions/ADR-012-typography-tokens-divergence.md",
+      "url": "https://uxindesign.github.io/design-system-core/docs/decisions/adr-012-typography-tokens-divergence.html"
     }
   ]
 }

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T22:52:18.896Z",
-  "version": "0.5.15",
+  "generatedAt": "2026-04-21T23:19:17.419Z",
+  "version": "0.5.16",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T22:52:18.896Z",
-  "version": "0.5.15",
+  "generatedAt": "2026-04-21T23:19:17.419Z",
+  "version": "0.5.16",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T22:52:19.361Z",
+  "generatedAt": "2026-04-21T23:19:17.897Z",
   "totals": {
     "jsonTokens": 632,
     "sharedTokens": 368,

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T22:52:18.896Z",
-  "version": "0.5.15",
+  "generatedAt": "2026-04-21T23:19:17.419Z",
+  "version": "0.5.16",
   "counts": {
     "foundation": 231,
     "semanticLight": 132,

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,22 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.16]</h2>
+<h3>Adicionado</h3>
+<ul>
+<li><strong>ADR-012</strong> — <em>Tokens de line-height e letter-spacing divergem por design entre Figma e JSON.</em> Formaliza que esses dois grupos de tokens são representados em unidades incompatíveis (PX no Figma vs ratio/rem/em no JSON) por limitação da Plugin API do Figma e requisito WCAG 1.4.4 do CSS. Os dois lados são canônicos em seus contextos de consumo; <strong>não sincronizam entre si</strong>.</li>
+<li><strong>Categoria <code>BY_DESIGN</code></strong> no sync Figma → JSON. Listas <code>FIGMA_ONLY_PATHS</code> e <code>JSON_ONLY_PATHS</code> em <code>scripts/lib/figma-dtcg.mjs</code> reconhecem tokens que existem só de um lado por escolha documentada. Ficam em <code>BY_DESIGN</code> (informativo) em vez de falso-positivarem como <code>NEW_IN_FIGMA</code> ou <code>MISSING_IN_FIGMA</code>.</li>
+</ul>
+<h3>Corrigido (efeito do ADR-012 no sync)</h3>
+<p>Antes: sync reportava <strong>23 NEW_IN_FIGMA + 14 MISSING_IN_FIGMA</strong> (37 falsos drifts) em line-height/letter-spacing, mascarando drifts reais.</p>
+<p>Depois: <strong>0 NEW_IN_FIGMA + 0 MISSING_IN_FIGMA + 37 BY_DESIGN</strong> (informativo). Dry-run sai com exit 0. Qualquer drift novo em typography (ex: valor real diferente em <code>semantic.brand.hover</code>) continua detectado.</p>
+<h3>Atualizado</h3>
+<ul>
+<li><code>docs/process-figma-sync.md</code>: tabela de categorias passou de 4 pra 6 (inclui <code>CSS_ONLY</code> e <code>BY_DESIGN</code>, ambas marcadas como &quot;não aplica em <code>--write</code>&quot;).</li>
+<li><code>scripts/sync-tokens-from-figma.mjs</code>: relatório inclui contagem e seção <code>BY_DESIGN</code> com indicação de lado (<code>figma-only</code> ou <code>json-only</code>).</li>
+</ul>
+<h3>Contexto operacional</h3>
+<p>Issue #23 (origem) fica <strong>fechada</strong> com este PR. Questão de unificação futura via composite typography tokens fica em issue #27 (ADR-013 a abrir quando for priorizada).</p>
 <h2>[0.5.15]</h2>
 <h3>Consolidado</h3>
 <p>Auditoria do <code>CLAUDE.md</code> contra o estado real do repo + Figma + contexto externo (que vivia em workspace Claude Project). Objetivo: tornar o repo fonte única de verdade, sem ambiguidades.</p>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.15**
+> Versão atual: **0.5.16**
 
 ## Status geral
 
@@ -69,6 +69,7 @@
 | ADR-009 | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 |
 | ADR-010 | Remoção de `foundation.color.white` e `foundation.color.black` puros | Aceita — Implementada em 0.5.0 |
 | ADR-011 | Reestruturação do naming de tokens semânticos de cor | Aceita — Implementada em 0.5.0 |
+| ADR-012 | Tokens de line-height e letter-spacing divergem por design entre Figma e JSON | Aceita |
 
 ## Próximos milestones
 

--- a/docs/decisions/ADR-012-typography-tokens-divergence.md
+++ b/docs/decisions/ADR-012-typography-tokens-divergence.md
@@ -1,0 +1,91 @@
+# ADR-012: Tokens de line-height e letter-spacing divergem por design entre Figma e JSON
+
+**Data:** 2026-04-21
+**Status:** Aceita
+
+## Contexto
+
+Em 21/04/2026, durante os PRs #17-#22 (0.5.10 → 0.5.15), implementamos o sync Figma → JSON via MCP e consolidamos a hierarquia de verdade ("Figma é autoridade de valor; JSON é consolidação canônica"). Ao rodar o sync, 37 tokens de typography aparecem como divergentes:
+
+- **23 NEW_IN_FIGMA**: `typography/font/line-height/*` (`tight`, `snug`, `normal`, `relaxed`, e `16`, `18`, `20`, `22`, `24`, `26`, `28`, `34`, `40`, `44`, `50`, `60`, `70`, `80`, `90`), `typography/font/letter-spacing/*` (`tight`, `normal`, `wide`, `wider`).
+- **14 MISSING_IN_FIGMA**: `foundation.typography.line.height.*` (`none`, `tight`, `snug`, `normal`, `relaxed`, `loose`, `control.sm/md/lg`), `foundation.typography.letter.spacing.*` (`tighter`, `tight`, `normal`, `wide`, `wider`).
+
+Não é "um lado está desatualizado". Figma e JSON **representam o mesmo conceito em unidades incompatíveis** porque Figma e CSS têm capacidades diferentes:
+
+| Aspecto | Figma Variables | CSS / JSON |
+|---|---|---|
+| Unidade pra `line-height` | **PX obrigatório** (Plugin API só aceita `{unit: "PIXELS"\|"PERCENT", value: number}`) | **Ratio unitless** preferido (herdável, escalável), ou `rem`/`em` |
+| Unidade pra `letter-spacing` | **PX obrigatório** | **`em` preferido** (proporcional ao font-size) |
+| Tipagem DTCG | não há `$type: dimension` com unidade flexível | `$value: "1.25"` (ratio) ou `"0.5rem"` |
+| Consumo | 24 dos 28 text styles consomem via `boundVariables` | 20 consumos de `--ds-line-height-*` em 8 componentes CSS |
+
+**Consequência**: converter um lado pro outro causa perda real.
+
+- Converter JSON pra PX: quebra acessibilidade (WCAG 1.4.4 "Resize Text"). Elementos em `px` não escalam com o zoom de texto do browser. Elementos em `rem`/`em`/unitless escalam.
+- Converter Figma pra ratio: não funciona. A Plugin API não aceita unidade unitless em `lineHeight` de text style. O Figma registra internamente como PERCENT (`150 → 150%`) ou PIXELS, mas o binding precisa de Variable do tipo `FLOAT` com valor numérico que o Figma interpreta como px ou %.
+
+## Decisão
+
+Tokens de `line-height` e `letter-spacing` têm **representação divergente por design** entre Figma e JSON. Ambos os lados são canônicos no seu contexto de consumo.
+
+### Regra
+
+1. **Figma** mantém `typography/font/line-height/*` e `typography/font/letter-spacing/*` como autoridade para os **text styles do Figma**. Valores em PX (números puros; Figma interpreta como px quando aplicado a text node).
+2. **JSON** mantém `foundation.typography.line.height.*` e `foundation.typography.letter.spacing.*` como autoridade para o **CSS gerado**. Valores em ratio unitless (line-height) e `em` (letter-spacing).
+3. O sync Figma → JSON **não sincroniza** esses tokens — cada lado evolui independentemente dentro da sua representação.
+4. Mudanças visuais de typography que afetam os dois lados (ex: deixar um heading mais "aberto") exigem **atualização manual em ambos** — Figma via text style, JSON via `foundation/typography.json`.
+
+### Mecanismo técnico
+
+No `scripts/lib/figma-dtcg.mjs`, introduzimos duas listas de regex:
+
+```js
+const FIGMA_ONLY_PATHS = [
+  /^foundation\.typography\.font\.line-height\./,
+  /^foundation\.typography\.font\.letter-spacing\./,
+];
+const JSON_ONLY_PATHS = [
+  /^foundation\.typography\.line\.height\./,
+  /^foundation\.typography\.letter\.spacing\./,
+];
+```
+
+Na função `compareStates`:
+
+- Tokens com path casando `FIGMA_ONLY_PATHS` que seriam `NEW_IN_FIGMA` → vão pra categoria `BY_DESIGN` (informativa).
+- Tokens com path casando `JSON_ONLY_PATHS` que seriam `MISSING_IN_FIGMA` → idem.
+- Categoria `BY_DESIGN` é listada no relatório mas **não conta como drift**. Exit code 0 quando é o único resto.
+
+### Diferença semântica vs `CSS_ONLY`
+
+Este ADR introduz `BY_DESIGN`; não se confunde com a categoria `CSS_ONLY` existente:
+
+- `CSS_ONLY` (introduzido em 0.5.11 pós-PR #18): tokens que **existem dos dois lados** mas têm **valores representados diferentemente** (ex: `foundation.typography.font.family.sans` = `"Inter"` no Figma vs stack completa `'Inter', system-ui, ...` no JSON). Sync ignora a diferença de valor.
+- `BY_DESIGN` (este ADR): tokens que **existem só de um lado** por escolha arquitetural. Sync ignora a ausência do outro lado.
+
+## Consequências
+
+- Dry-run do sync sai mais limpo: `0 VALUE_DRIFT, 0 NEW_IN_FIGMA, 0 MISSING_IN_FIGMA, 0 ALIAS_BROKEN, 9 CSS_ONLY, 37 BY_DESIGN`. Divergências reais ficam visíveis sem o ruído de 37 falsos positivos.
+- Quem for ajustar typography precisa saber que os dois lados são independentes. Documentado em `docs/process-figma-sync.md` e reforçado por `$description` nos tokens afetados (follow-up).
+- Se no futuro DTCG/CSS ganharem suporte nativo a composite typography tokens (issue #27), dá pra revisitar essa decisão e unificar.
+
+## Alternativas consideradas
+
+**(a) Unificar em PX.** Remove rem/ratio do JSON, adota PX nos dois lados. Descartada por quebrar WCAG 1.4.4 e a convenção CSS moderna (unitless line-height é recomendado pela especificação CSS desde Level 2).
+
+**(b) Unificar em ratio/em.** Remove os PX do Figma. Descartada porque a Plugin API do Figma não aceita line-height unitless; e porque designer precisa trabalhar em px absoluto durante composição visual.
+
+**(c) Criar "composite typography tokens"** (DTCG `$type: typography`). Agruparia fontFamily + fontWeight + fontSize + lineHeight + letterSpacing num único token nomeado (ex: `display/2xl`). Resolve parcialmente mas exige migração grande. Movido pra issue #27 como evolução futura; não bloqueia este ADR.
+
+**(d) Duplicar tudo de um lado no outro (manter ambos, sincronizar manualmente).** Descartada — dobra o custo de manutenção e convida drift silencioso. Melhor aceitar a divergência explicitamente.
+
+## Referências
+
+- [ADR-001](./ADR-001-migracao-tokens.md) — arquitetura Foundation → Semantic → Component.
+- [ADR-003](./ADR-003-fontes-verdade.md) revisada — Figma = autoridade de valor.
+- [ADR-006](./ADR-006-semantic-control-tokens.md) — tokens semânticos de controle (inclui `typography.control.*`).
+- `docs/process-figma-sync.md` — fluxo operacional do sync.
+- Issue #23 (origem desta decisão).
+- Issue #27 — composite typography tokens (evolução futura).
+- [CSS Values and Units Level 4 §3.5](https://www.w3.org/TR/css-values-4/) — unidades relativas (rem, em).
+- [WCAG 2.2 — 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html) — requisito de acessibilidade que justifica ratio/rem.

--- a/docs/decisions/adr-012-typography-tokens-divergence.html
+++ b/docs/decisions/adr-012-typography-tokens-divergence.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADR-012 — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON — Design System</title>
+  <link rel="stylesheet" href="../../css/design-system.css">
+  <link rel="stylesheet" href="../layout.css">
+  <style>
+    .ds-md-content h1, .ds-md-content h2, .ds-md-content h3 { margin-top: var(--ds-spacing-8); margin-bottom: var(--ds-spacing-3); color: var(--ds-content-default); }
+    .ds-md-content h1 { font-size: var(--ds-font-size-2xl); font-weight: var(--ds-font-weight-semibold); margin-top: 0; }
+    .ds-md-content h2 { font-size: var(--ds-font-size-xl); font-weight: var(--ds-font-weight-semibold); border-top: var(--ds-border-width-1) solid var(--ds-border-subtle); padding-top: var(--ds-spacing-6); }
+    .ds-md-content h3 { font-size: var(--ds-font-size-lg); font-weight: var(--ds-font-weight-semibold); }
+    .ds-md-content p { color: var(--ds-content-secondary); line-height: var(--ds-line-height-relaxed); margin: var(--ds-spacing-3) 0; }
+    .ds-md-content ul, .ds-md-content ol { color: var(--ds-content-secondary); line-height: var(--ds-line-height-relaxed); padding-left: var(--ds-spacing-6); margin: var(--ds-spacing-3) 0; }
+    .ds-md-content li { margin: var(--ds-spacing-1) 0; }
+    .ds-md-content code { font-family: var(--ds-font-family-mono); font-size: 0.9em; background: var(--ds-background-subtle); color: var(--ds-content-link-default); padding: 1px var(--ds-spacing-1); border-radius: var(--ds-radius-sm); }
+    .ds-md-content pre { background: var(--ds-color-neutral-900); color: var(--ds-color-neutral-100); padding: var(--ds-spacing-4); border-radius: var(--ds-radius-md); overflow-x: auto; font-size: var(--ds-font-size-sm); margin: var(--ds-spacing-4) 0; }
+    .ds-md-content pre code { background: none; color: inherit; padding: 0; }
+    .ds-md-content table { width: 100%; border-collapse: collapse; margin: var(--ds-spacing-4) 0; font-size: var(--ds-font-size-sm); }
+    .ds-md-content table th, .ds-md-content table td { text-align: left; padding: var(--ds-spacing-2) var(--ds-spacing-3); border-bottom: var(--ds-border-width-1) solid var(--ds-border-default); }
+    .ds-md-content table th { font-weight: var(--ds-font-weight-semibold); background: var(--ds-background-subtle); }
+    .ds-md-content a { color: var(--ds-content-link-default); }
+    .ds-md-content a:hover { color: var(--ds-content-link-hover); }
+    .ds-md-content blockquote { border-left: 3px solid var(--ds-border-default); margin: var(--ds-spacing-4) 0; padding: var(--ds-spacing-2) var(--ds-spacing-4); color: var(--ds-content-tertiary); font-style: italic; }
+    .ds-md-content hr { border: none; border-top: var(--ds-border-width-1) solid var(--ds-border-subtle); margin: var(--ds-spacing-8) 0; }
+    .ds-md-content strong { color: var(--ds-content-default); }
+    .ds-md-generated-banner { background: var(--ds-feedback-info-background); color: var(--ds-feedback-info-content-default); padding: var(--ds-spacing-3) var(--ds-spacing-5); border-radius: var(--ds-radius-md); margin-bottom: var(--ds-spacing-6); font-size: var(--ds-font-size-sm); }
+  </style>
+  <script>
+    (function(){var l=localStorage.getItem('ds-lang');if(l)document.documentElement.setAttribute('lang',l)})();
+  </script>
+</head>
+<body>
+
+<header class="ds-site-header">
+  <div style="display:flex;align-items:center;gap:var(--ds-spacing-4)">
+    <button class="ds-menu-toggle" id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+    </button>
+    <a href="../../index.html" class="ds-site-header__brand">
+      <div class="ds-site-header__logo">DS</div>
+      <span class="ds-site-header__title">Design System</span>
+    </a>
+  </div>
+  <div class="ds-site-header__actions">
+    <select class="ds-theme-switcher__select" id="lang-switcher" aria-label="Language">
+      <option value="pt">PT</option>
+      <option value="en">EN</option>
+    </select>
+    <select class="ds-theme-switcher__select" id="theme-switcher">
+      <option value="default">Default (Blue)</option>
+      <option value="ocean">Ocean (Cyan)</option>
+      <option value="forest">Forest (Emerald)</option>
+    </select>
+    <button class="ds-btn ds-btn--ghost ds-btn--sm" id="mode-toggle" aria-pressed="false" aria-label="Toggle dark mode"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26 5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg> Dark</button>
+  </div>
+</header>
+<div class="ds-sidebar-overlay" id="sidebar-overlay"></div>
+<nav class="ds-sidebar" id="sidebar" aria-label="Main navigation"></nav>
+
+<main class="ds-main">
+  <div class="ds-section">
+    <h1 class="ds-section__title">ADR-012 — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON</h1>
+    <p class="ds-section__subtitle">Status: <strong>Aceita</strong> · Data: 2026-04-21</p>
+  </div>
+
+  <div class="ds-md-generated-banner">
+    Este arquivo é gerado automaticamente por <code>scripts/sync-docs.mjs</code>. Editar a fonte original, não este HTML.
+  </div>
+
+  <div class="ds-md-content">
+<p><strong>Data:</strong> 2026-04-21
+<strong>Status:</strong> Aceita</p>
+<h2>Contexto</h2>
+<p>Em 21/04/2026, durante os PRs #17-#22 (0.5.10 → 0.5.15), implementamos o sync Figma → JSON via MCP e consolidamos a hierarquia de verdade (&quot;Figma é autoridade de valor; JSON é consolidação canônica&quot;). Ao rodar o sync, 37 tokens de typography aparecem como divergentes:</p>
+<ul>
+<li><strong>23 NEW_IN_FIGMA</strong>: <code>typography/font/line-height/*</code> (<code>tight</code>, <code>snug</code>, <code>normal</code>, <code>relaxed</code>, e <code>16</code>, <code>18</code>, <code>20</code>, <code>22</code>, <code>24</code>, <code>26</code>, <code>28</code>, <code>34</code>, <code>40</code>, <code>44</code>, <code>50</code>, <code>60</code>, <code>70</code>, <code>80</code>, <code>90</code>), <code>typography/font/letter-spacing/*</code> (<code>tight</code>, <code>normal</code>, <code>wide</code>, <code>wider</code>).</li>
+<li><strong>14 MISSING_IN_FIGMA</strong>: <code>foundation.typography.line.height.*</code> (<code>none</code>, <code>tight</code>, <code>snug</code>, <code>normal</code>, <code>relaxed</code>, <code>loose</code>, <code>control.sm/md/lg</code>), <code>foundation.typography.letter.spacing.*</code> (<code>tighter</code>, <code>tight</code>, <code>normal</code>, <code>wide</code>, <code>wider</code>).</li>
+</ul>
+<p>Não é &quot;um lado está desatualizado&quot;. Figma e JSON <strong>representam o mesmo conceito em unidades incompatíveis</strong> porque Figma e CSS têm capacidades diferentes:</p>
+<table>
+<thead>
+<tr>
+<th>Aspecto</th>
+<th>Figma Variables</th>
+<th>CSS / JSON</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Unidade pra <code>line-height</code></td>
+<td><strong>PX obrigatório</strong> (Plugin API só aceita <code>{unit: &quot;PIXELS&quot;|&quot;PERCENT&quot;, value: number}</code>)</td>
+<td><strong>Ratio unitless</strong> preferido (herdável, escalável), ou <code>rem</code>/<code>em</code></td>
+</tr>
+<tr>
+<td>Unidade pra <code>letter-spacing</code></td>
+<td><strong>PX obrigatório</strong></td>
+<td><strong><code>em</code> preferido</strong> (proporcional ao font-size)</td>
+</tr>
+<tr>
+<td>Tipagem DTCG</td>
+<td>não há <code>$type: dimension</code> com unidade flexível</td>
+<td><code>$value: &quot;1.25&quot;</code> (ratio) ou <code>&quot;0.5rem&quot;</code></td>
+</tr>
+<tr>
+<td>Consumo</td>
+<td>24 dos 28 text styles consomem via <code>boundVariables</code></td>
+<td>20 consumos de <code>--ds-line-height-*</code> em 8 componentes CSS</td>
+</tr>
+</tbody></table>
+<p><strong>Consequência</strong>: converter um lado pro outro causa perda real.</p>
+<ul>
+<li>Converter JSON pra PX: quebra acessibilidade (WCAG 1.4.4 &quot;Resize Text&quot;). Elementos em <code>px</code> não escalam com o zoom de texto do browser. Elementos em <code>rem</code>/<code>em</code>/unitless escalam.</li>
+<li>Converter Figma pra ratio: não funciona. A Plugin API não aceita unidade unitless em <code>lineHeight</code> de text style. O Figma registra internamente como PERCENT (<code>150 → 150%</code>) ou PIXELS, mas o binding precisa de Variable do tipo <code>FLOAT</code> com valor numérico que o Figma interpreta como px ou %.</li>
+</ul>
+<h2>Decisão</h2>
+<p>Tokens de <code>line-height</code> e <code>letter-spacing</code> têm <strong>representação divergente por design</strong> entre Figma e JSON. Ambos os lados são canônicos no seu contexto de consumo.</p>
+<h3>Regra</h3>
+<ol>
+<li><strong>Figma</strong> mantém <code>typography/font/line-height/*</code> e <code>typography/font/letter-spacing/*</code> como autoridade para os <strong>text styles do Figma</strong>. Valores em PX (números puros; Figma interpreta como px quando aplicado a text node).</li>
+<li><strong>JSON</strong> mantém <code>foundation.typography.line.height.*</code> e <code>foundation.typography.letter.spacing.*</code> como autoridade para o <strong>CSS gerado</strong>. Valores em ratio unitless (line-height) e <code>em</code> (letter-spacing).</li>
+<li>O sync Figma → JSON <strong>não sincroniza</strong> esses tokens — cada lado evolui independentemente dentro da sua representação.</li>
+<li>Mudanças visuais de typography que afetam os dois lados (ex: deixar um heading mais &quot;aberto&quot;) exigem <strong>atualização manual em ambos</strong> — Figma via text style, JSON via <code>foundation/typography.json</code>.</li>
+</ol>
+<h3>Mecanismo técnico</h3>
+<p>No <code>scripts/lib/figma-dtcg.mjs</code>, introduzimos duas listas de regex:</p>
+<pre><code class="language-js">const FIGMA_ONLY_PATHS = [
+  /^foundation\.typography\.font\.line-height\./,
+  /^foundation\.typography\.font\.letter-spacing\./,
+];
+const JSON_ONLY_PATHS = [
+  /^foundation\.typography\.line\.height\./,
+  /^foundation\.typography\.letter\.spacing\./,
+];
+</code></pre>
+<p>Na função <code>compareStates</code>:</p>
+<ul>
+<li>Tokens com path casando <code>FIGMA_ONLY_PATHS</code> que seriam <code>NEW_IN_FIGMA</code> → vão pra categoria <code>BY_DESIGN</code> (informativa).</li>
+<li>Tokens com path casando <code>JSON_ONLY_PATHS</code> que seriam <code>MISSING_IN_FIGMA</code> → idem.</li>
+<li>Categoria <code>BY_DESIGN</code> é listada no relatório mas <strong>não conta como drift</strong>. Exit code 0 quando é o único resto.</li>
+</ul>
+<h3>Diferença semântica vs <code>CSS_ONLY</code></h3>
+<p>Este ADR introduz <code>BY_DESIGN</code>; não se confunde com a categoria <code>CSS_ONLY</code> existente:</p>
+<ul>
+<li><code>CSS_ONLY</code> (introduzido em 0.5.11 pós-PR #18): tokens que <strong>existem dos dois lados</strong> mas têm <strong>valores representados diferentemente</strong> (ex: <code>foundation.typography.font.family.sans</code> = <code>&quot;Inter&quot;</code> no Figma vs stack completa <code>&#39;Inter&#39;, system-ui, ...</code> no JSON). Sync ignora a diferença de valor.</li>
+<li><code>BY_DESIGN</code> (este ADR): tokens que <strong>existem só de um lado</strong> por escolha arquitetural. Sync ignora a ausência do outro lado.</li>
+</ul>
+<h2>Consequências</h2>
+<ul>
+<li>Dry-run do sync sai mais limpo: <code>0 VALUE_DRIFT, 0 NEW_IN_FIGMA, 0 MISSING_IN_FIGMA, 0 ALIAS_BROKEN, 9 CSS_ONLY, 37 BY_DESIGN</code>. Divergências reais ficam visíveis sem o ruído de 37 falsos positivos.</li>
+<li>Quem for ajustar typography precisa saber que os dois lados são independentes. Documentado em <code>docs/process-figma-sync.md</code> e reforçado por <code>$description</code> nos tokens afetados (follow-up).</li>
+<li>Se no futuro DTCG/CSS ganharem suporte nativo a composite typography tokens (issue #27), dá pra revisitar essa decisão e unificar.</li>
+</ul>
+<h2>Alternativas consideradas</h2>
+<p><strong>(a) Unificar em PX.</strong> Remove rem/ratio do JSON, adota PX nos dois lados. Descartada por quebrar WCAG 1.4.4 e a convenção CSS moderna (unitless line-height é recomendado pela especificação CSS desde Level 2).</p>
+<p><strong>(b) Unificar em ratio/em.</strong> Remove os PX do Figma. Descartada porque a Plugin API do Figma não aceita line-height unitless; e porque designer precisa trabalhar em px absoluto durante composição visual.</p>
+<p><strong>(c) Criar &quot;composite typography tokens&quot;</strong> (DTCG <code>$type: typography</code>). Agruparia fontFamily + fontWeight + fontSize + lineHeight + letterSpacing num único token nomeado (ex: <code>display/2xl</code>). Resolve parcialmente mas exige migração grande. Movido pra issue #27 como evolução futura; não bloqueia este ADR.</p>
+<p><strong>(d) Duplicar tudo de um lado no outro (manter ambos, sincronizar manualmente).</strong> Descartada — dobra o custo de manutenção e convida drift silencioso. Melhor aceitar a divergência explicitamente.</p>
+<h2>Referências</h2>
+<ul>
+<li><a href="./ADR-001-migracao-tokens.md">ADR-001</a> — arquitetura Foundation → Semantic → Component.</li>
+<li><a href="./ADR-003-fontes-verdade.md">ADR-003</a> revisada — Figma = autoridade de valor.</li>
+<li><a href="./ADR-006-semantic-control-tokens.md">ADR-006</a> — tokens semânticos de controle (inclui <code>typography.control.*</code>).</li>
+<li><code>docs/process-figma-sync.md</code> — fluxo operacional do sync.</li>
+<li>Issue #23 (origem desta decisão).</li>
+<li>Issue #27 — composite typography tokens (evolução futura).</li>
+<li><a href="https://www.w3.org/TR/css-values-4/">CSS Values and Units Level 4 §3.5</a> — unidades relativas (rem, em).</li>
+<li><a href="https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html">WCAG 2.2 — 1.4.4 Resize Text</a> — requisito de acessibilidade que justifica ratio/rem.</li>
+</ul>
+
+  </div>
+</main>
+
+<script src="../../js/main.js"></script>
+</body>
+</html>

--- a/docs/decisions/index.html
+++ b/docs/decisions/index.html
@@ -71,7 +71,7 @@
 
   <div class="ds-md-content">
 
-<p>11 decisões registradas. HTMLs gerados automaticamente a partir dos <code>.md</code> correspondentes.</p>
+<p>12 decisões registradas. HTMLs gerados automaticamente a partir dos <code>.md</code> correspondentes.</p>
 <table>
 <thead><tr><th>ADR</th><th>Título</th><th>Status</th><th>Data</th></tr></thead>
 <tbody>
@@ -86,6 +86,7 @@
 <tr><td><a href="adr-009-border-control-vs-decorative.html">ADR-009</a></td><td>Separação de `border.default` (decorativa) e `border.control` (funcional)</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-16</td></tr>
 <tr><td><a href="adr-010-abolir-white-black-puros.html">ADR-010</a></td><td>Remoção de `foundation.color.white` e `foundation.color.black` puros</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-16</td></tr>
 <tr><td><a href="adr-011-renaming-tokens-semanticos-de-cor.html">ADR-011</a></td><td>Reestruturação do naming de tokens semânticos de cor</td><td>Aceita — Implementada em 0.5.0</td><td>2026-04-17</td></tr>
+<tr><td><a href="adr-012-typography-tokens-divergence.html">ADR-012</a></td><td>Tokens de line-height e letter-spacing divergem por design entre Figma e JSON</td><td>Aceita</td><td>2026-04-21</td></tr>
 </tbody>
 </table>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.5.15. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.5.16. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -351,6 +351,24 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em `docs/process-versioning.html`.
 
 ## [Não publicado]
+
+## [0.5.16]
+
+### Adicionado
+- **ADR-012** — *Tokens de line-height e letter-spacing divergem por design entre Figma e JSON.* Formaliza que esses dois grupos de tokens são representados em unidades incompatíveis (PX no Figma vs ratio/rem/em no JSON) por limitação da Plugin API do Figma e requisito WCAG 1.4.4 do CSS. Os dois lados são canônicos em seus contextos de consumo; **não sincronizam entre si**.
+- **Categoria `BY_DESIGN`** no sync Figma → JSON. Listas `FIGMA_ONLY_PATHS` e `JSON_ONLY_PATHS` em `scripts/lib/figma-dtcg.mjs` reconhecem tokens que existem só de um lado por escolha documentada. Ficam em `BY_DESIGN` (informativo) em vez de falso-positivarem como `NEW_IN_FIGMA` ou `MISSING_IN_FIGMA`.
+
+### Corrigido (efeito do ADR-012 no sync)
+Antes: sync reportava **23 NEW_IN_FIGMA + 14 MISSING_IN_FIGMA** (37 falsos drifts) em line-height/letter-spacing, mascarando drifts reais.
+
+Depois: **0 NEW_IN_FIGMA + 0 MISSING_IN_FIGMA + 37 BY_DESIGN** (informativo). Dry-run sai com exit 0. Qualquer drift novo em typography (ex: valor real diferente em `semantic.brand.hover`) continua detectado.
+
+### Atualizado
+- `docs/process-figma-sync.md`: tabela de categorias passou de 4 pra 6 (inclui `CSS_ONLY` e `BY_DESIGN`, ambas marcadas como "não aplica em `--write`").
+- `scripts/sync-tokens-from-figma.mjs`: relatório inclui contagem e seção `BY_DESIGN` com indicação de lado (`figma-only` ou `json-only`).
+
+### Contexto operacional
+Issue #23 (origem) fica **fechada** com este PR. Questão de unificação futura via composite typography tokens fica em issue #27 (ADR-013 a abrir quando for priorizada).
 
 ## [0.5.15]
 
@@ -705,7 +723,7 @@ Consolidação da documentação como fonte única de verdade. Plano em seis fas
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
 
-11 decisões registradas.
+12 decisões registradas.
 
 | ADR | Título | Status | Data |
 |-----|--------|--------|------|
@@ -720,6 +738,7 @@ Consolidação da documentação como fonte única de verdade. Plano em seis fas
 | [ADR-009](decisions/ADR-009-border-control-vs-decorative.md) | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 | 2026-04-16 |
 | [ADR-010](decisions/ADR-010-abolir-white-black-puros.md) | Remoção de `foundation.color.white` e `foundation.color.black` puros | Aceita — Implementada em 0.5.0 | 2026-04-16 |
 | [ADR-011](decisions/ADR-011-renaming-tokens-semanticos-de-cor.md) | Reestruturação do naming de tokens semânticos de cor | Aceita — Implementada em 0.5.0 | 2026-04-17 |
+| [ADR-012](decisions/ADR-012-typography-tokens-divergence.md) | Tokens de line-height e letter-spacing divergem por design entre Figma e JSON | Aceita | 2026-04-21 |
 
 
 ═══════════════════════════════════════════════════════════
@@ -905,7 +924,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.15**
+> Versão atual: **0.5.16**
 
 ## Status geral
 
@@ -972,6 +991,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 | ADR-009 | Separação de `border.default` (decorativa) e `border.control` (funcional) | Aceita — Implementada em 0.5.0 |
 | ADR-010 | Remoção de `foundation.color.white` e `foundation.color.black` puros | Aceita — Implementada em 0.5.0 |
 | ADR-011 | Reestruturação do naming de tokens semânticos de cor | Aceita — Implementada em 0.5.0 |
+| ADR-012 | Tokens de line-height e letter-spacing divergem por design entre Figma e JSON | Aceita |
 
 ## Próximos milestones
 
@@ -1129,7 +1149,7 @@ O script:
 1. Lê `.figma-snapshot.json` (ou `--snapshot <path>` pra outro caminho).
 2. Constrói o estado esperado dos JSONs (`tokens/foundation/`, `tokens/semantic/`, `tokens/component/`) a partir das Variables.
 3. Lê os JSONs atuais e compara.
-4. Reporta em 4 categorias:
+4. Reporta em 6 categorias:
 
 | Categoria | Significado | Ação em `--write` |
 |-----------|-------------|-------------------|
@@ -1137,10 +1157,14 @@ O script:
 | **NEW_IN_FIGMA** | Figma tem, JSON não. | Não cria — revisão manual. |
 | **MISSING_IN_FIGMA** | JSON tem, Figma não. | Não deleta — revisão manual. |
 | **ALIAS_BROKEN** | Figma aponta pra variável inexistente. | Não resolve — fix no Figma. |
+| **CSS_ONLY** | Token existe dos dois lados mas representação diverge por capacidade CSS (font family stack, `rem`, weight numérico). Introduzido após PR #18 / 0.5.11. | **Não aplica** — aplicar regridiria o CSS (ex: trocaria `'Inter', system-ui, ...` por `"Inter"`; ou `0.875rem` por `14`, quebrando WCAG 1.4.4). |
+| **BY_DESIGN** | Token existe só de um lado por escolha arquitetural documentada — ver **ADR-012** (line-height/letter-spacing: PX no Figma, ratio/em no JSON). | **Não aplica** — não é drift, é arquitetura. |
 
-Se tudo zerar, Figma e JSON estão em dia. Exit 0.
+Se as 4 primeiras categorias zerarem, Figma e JSON estão em dia. Exit 0.
 
-Se tem divergências, exit 1. Review no output antes de aplicar.
+Se tem divergências reais (VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA), exit 1. CSS_ONLY e BY_DESIGN são informativos — não contam como divergência.
+
+Review no output antes de aplicar.
 
 ## Passo 3 — aplicar VALUE_DRIFT
 
@@ -1523,13 +1547,13 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.15**
+> Versão atual: **0.5.16**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.15 |
+| Versão | 0.5.16 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -1622,6 +1646,7 @@ semantic.typography.*
 - **ADR-009** — Separação de `border.default` (decorativa) e `border.control` (funcional) (Aceita — Implementada em 0.5.0)
 - **ADR-010** — Remoção de `foundation.color.white` e `foundation.color.black` puros (Aceita — Implementada em 0.5.0)
 - **ADR-011** — Reestruturação do naming de tokens semânticos de cor (Aceita — Implementada em 0.5.0)
+- **ADR-012** — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON (Aceita)
 
 
 ═══════════════════════════════════════════════════════════
@@ -2945,6 +2970,103 @@ Rejeitada. Dobraria a quantidade de tokens de conteúdo (~15 → ~30) para resol
 
 
 ═══════════════════════════════════════════════════════════
+# ADR-012 — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON
+═══════════════════════════════════════════════════════════
+
+# ADR-012: Tokens de line-height e letter-spacing divergem por design entre Figma e JSON
+
+**Data:** 2026-04-21
+**Status:** Aceita
+
+## Contexto
+
+Em 21/04/2026, durante os PRs #17-#22 (0.5.10 → 0.5.15), implementamos o sync Figma → JSON via MCP e consolidamos a hierarquia de verdade ("Figma é autoridade de valor; JSON é consolidação canônica"). Ao rodar o sync, 37 tokens de typography aparecem como divergentes:
+
+- **23 NEW_IN_FIGMA**: `typography/font/line-height/*` (`tight`, `snug`, `normal`, `relaxed`, e `16`, `18`, `20`, `22`, `24`, `26`, `28`, `34`, `40`, `44`, `50`, `60`, `70`, `80`, `90`), `typography/font/letter-spacing/*` (`tight`, `normal`, `wide`, `wider`).
+- **14 MISSING_IN_FIGMA**: `foundation.typography.line.height.*` (`none`, `tight`, `snug`, `normal`, `relaxed`, `loose`, `control.sm/md/lg`), `foundation.typography.letter.spacing.*` (`tighter`, `tight`, `normal`, `wide`, `wider`).
+
+Não é "um lado está desatualizado". Figma e JSON **representam o mesmo conceito em unidades incompatíveis** porque Figma e CSS têm capacidades diferentes:
+
+| Aspecto | Figma Variables | CSS / JSON |
+|---|---|---|
+| Unidade pra `line-height` | **PX obrigatório** (Plugin API só aceita `{unit: "PIXELS"\|"PERCENT", value: number}`) | **Ratio unitless** preferido (herdável, escalável), ou `rem`/`em` |
+| Unidade pra `letter-spacing` | **PX obrigatório** | **`em` preferido** (proporcional ao font-size) |
+| Tipagem DTCG | não há `$type: dimension` com unidade flexível | `$value: "1.25"` (ratio) ou `"0.5rem"` |
+| Consumo | 24 dos 28 text styles consomem via `boundVariables` | 20 consumos de `--ds-line-height-*` em 8 componentes CSS |
+
+**Consequência**: converter um lado pro outro causa perda real.
+
+- Converter JSON pra PX: quebra acessibilidade (WCAG 1.4.4 "Resize Text"). Elementos em `px` não escalam com o zoom de texto do browser. Elementos em `rem`/`em`/unitless escalam.
+- Converter Figma pra ratio: não funciona. A Plugin API não aceita unidade unitless em `lineHeight` de text style. O Figma registra internamente como PERCENT (`150 → 150%`) ou PIXELS, mas o binding precisa de Variable do tipo `FLOAT` com valor numérico que o Figma interpreta como px ou %.
+
+## Decisão
+
+Tokens de `line-height` e `letter-spacing` têm **representação divergente por design** entre Figma e JSON. Ambos os lados são canônicos no seu contexto de consumo.
+
+### Regra
+
+1. **Figma** mantém `typography/font/line-height/*` e `typography/font/letter-spacing/*` como autoridade para os **text styles do Figma**. Valores em PX (números puros; Figma interpreta como px quando aplicado a text node).
+2. **JSON** mantém `foundation.typography.line.height.*` e `foundation.typography.letter.spacing.*` como autoridade para o **CSS gerado**. Valores em ratio unitless (line-height) e `em` (letter-spacing).
+3. O sync Figma → JSON **não sincroniza** esses tokens — cada lado evolui independentemente dentro da sua representação.
+4. Mudanças visuais de typography que afetam os dois lados (ex: deixar um heading mais "aberto") exigem **atualização manual em ambos** — Figma via text style, JSON via `foundation/typography.json`.
+
+### Mecanismo técnico
+
+No `scripts/lib/figma-dtcg.mjs`, introduzimos duas listas de regex:
+
+```js
+const FIGMA_ONLY_PATHS = [
+  /^foundation\.typography\.font\.line-height\./,
+  /^foundation\.typography\.font\.letter-spacing\./,
+];
+const JSON_ONLY_PATHS = [
+  /^foundation\.typography\.line\.height\./,
+  /^foundation\.typography\.letter\.spacing\./,
+];
+```
+
+Na função `compareStates`:
+
+- Tokens com path casando `FIGMA_ONLY_PATHS` que seriam `NEW_IN_FIGMA` → vão pra categoria `BY_DESIGN` (informativa).
+- Tokens com path casando `JSON_ONLY_PATHS` que seriam `MISSING_IN_FIGMA` → idem.
+- Categoria `BY_DESIGN` é listada no relatório mas **não conta como drift**. Exit code 0 quando é o único resto.
+
+### Diferença semântica vs `CSS_ONLY`
+
+Este ADR introduz `BY_DESIGN`; não se confunde com a categoria `CSS_ONLY` existente:
+
+- `CSS_ONLY` (introduzido em 0.5.11 pós-PR #18): tokens que **existem dos dois lados** mas têm **valores representados diferentemente** (ex: `foundation.typography.font.family.sans` = `"Inter"` no Figma vs stack completa `'Inter', system-ui, ...` no JSON). Sync ignora a diferença de valor.
+- `BY_DESIGN` (este ADR): tokens que **existem só de um lado** por escolha arquitetural. Sync ignora a ausência do outro lado.
+
+## Consequências
+
+- Dry-run do sync sai mais limpo: `0 VALUE_DRIFT, 0 NEW_IN_FIGMA, 0 MISSING_IN_FIGMA, 0 ALIAS_BROKEN, 9 CSS_ONLY, 37 BY_DESIGN`. Divergências reais ficam visíveis sem o ruído de 37 falsos positivos.
+- Quem for ajustar typography precisa saber que os dois lados são independentes. Documentado em `docs/process-figma-sync.md` e reforçado por `$description` nos tokens afetados (follow-up).
+- Se no futuro DTCG/CSS ganharem suporte nativo a composite typography tokens (issue #27), dá pra revisitar essa decisão e unificar.
+
+## Alternativas consideradas
+
+**(a) Unificar em PX.** Remove rem/ratio do JSON, adota PX nos dois lados. Descartada por quebrar WCAG 1.4.4 e a convenção CSS moderna (unitless line-height é recomendado pela especificação CSS desde Level 2).
+
+**(b) Unificar em ratio/em.** Remove os PX do Figma. Descartada porque a Plugin API do Figma não aceita line-height unitless; e porque designer precisa trabalhar em px absoluto durante composição visual.
+
+**(c) Criar "composite typography tokens"** (DTCG `$type: typography`). Agruparia fontFamily + fontWeight + fontSize + lineHeight + letterSpacing num único token nomeado (ex: `display/2xl`). Resolve parcialmente mas exige migração grande. Movido pra issue #27 como evolução futura; não bloqueia este ADR.
+
+**(d) Duplicar tudo de um lado no outro (manter ambos, sincronizar manualmente).** Descartada — dobra o custo de manutenção e convida drift silencioso. Melhor aceitar a divergência explicitamente.
+
+## Referências
+
+- [ADR-001](./ADR-001-migracao-tokens.md) — arquitetura Foundation → Semantic → Component.
+- [ADR-003](./ADR-003-fontes-verdade.md) revisada — Figma = autoridade de valor.
+- [ADR-006](./ADR-006-semantic-control-tokens.md) — tokens semânticos de controle (inclui `typography.control.*`).
+- `docs/process-figma-sync.md` — fluxo operacional do sync.
+- Issue #23 (origem desta decisão).
+- Issue #27 — composite typography tokens (evolução futura).
+- [CSS Values and Units Level 4 §3.5](https://www.w3.org/TR/css-values-4/) — unidades relativas (rem, em).
+- [WCAG 2.2 — 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html) — requisito de acessibilidade que justifica ratio/rem.
+
+
+═══════════════════════════════════════════════════════════
 # Tokens
 ═══════════════════════════════════════════════════════════
 
@@ -2963,6 +3085,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T22:52:19.134Z
-Versão: 0.5.15
+Gerado por scripts/build-llms.mjs em 2026-04-21T23:19:17.659Z
+Versão: 0.5.16
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.15. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.16. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -62,6 +62,7 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 - [ADR-009 — Separação de `border.default` (decorativa) e `border.control` (funcional)](https://uxindesign.github.io/design-system-core/docs/decisions/adr-009-border-control-vs-decorative.html) — Aceita — Implementada em 0.5.0
 - [ADR-010 — Remoção de `foundation.color.white` e `foundation.color.black` puros](https://uxindesign.github.io/design-system-core/docs/decisions/adr-010-abolir-white-black-puros.html) — Aceita — Implementada em 0.5.0
 - [ADR-011 — Reestruturação do naming de tokens semânticos de cor](https://uxindesign.github.io/design-system-core/docs/decisions/adr-011-renaming-tokens-semanticos-de-cor.html) — Aceita — Implementada em 0.5.0
+- [ADR-012 — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON](https://uxindesign.github.io/design-system-core/docs/decisions/adr-012-typography-tokens-divergence.html) — Aceita
 
 ## Processo
 
@@ -89,4 +90,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T22:52:19.134Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T23:19:17.659Z.

--- a/docs/process-figma-sync.md
+++ b/docs/process-figma-sync.md
@@ -61,7 +61,7 @@ O script:
 1. Lê `.figma-snapshot.json` (ou `--snapshot <path>` pra outro caminho).
 2. Constrói o estado esperado dos JSONs (`tokens/foundation/`, `tokens/semantic/`, `tokens/component/`) a partir das Variables.
 3. Lê os JSONs atuais e compara.
-4. Reporta em 4 categorias:
+4. Reporta em 6 categorias:
 
 | Categoria | Significado | Ação em `--write` |
 |-----------|-------------|-------------------|
@@ -69,10 +69,14 @@ O script:
 | **NEW_IN_FIGMA** | Figma tem, JSON não. | Não cria — revisão manual. |
 | **MISSING_IN_FIGMA** | JSON tem, Figma não. | Não deleta — revisão manual. |
 | **ALIAS_BROKEN** | Figma aponta pra variável inexistente. | Não resolve — fix no Figma. |
+| **CSS_ONLY** | Token existe dos dois lados mas representação diverge por capacidade CSS (font family stack, `rem`, weight numérico). Introduzido após PR #18 / 0.5.11. | **Não aplica** — aplicar regridiria o CSS (ex: trocaria `'Inter', system-ui, ...` por `"Inter"`; ou `0.875rem` por `14`, quebrando WCAG 1.4.4). |
+| **BY_DESIGN** | Token existe só de um lado por escolha arquitetural documentada — ver **ADR-012** (line-height/letter-spacing: PX no Figma, ratio/em no JSON). | **Não aplica** — não é drift, é arquitetura. |
 
-Se tudo zerar, Figma e JSON estão em dia. Exit 0.
+Se as 4 primeiras categorias zerarem, Figma e JSON estão em dia. Exit 0.
 
-Se tem divergências, exit 1. Review no output antes de aplicar.
+Se tem divergências reais (VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA), exit 1. CSS_ONLY e BY_DESIGN são informativos — não contam como divergência.
+
+Review no output antes de aplicar.
 
 ## Passo 3 — aplicar VALUE_DRIFT
 

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,13 +2,13 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.15**
+> Versão atual: **0.5.16**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.15 |
+| Versão | 0.5.16 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
@@ -101,3 +101,4 @@ semantic.typography.*
 - **ADR-009** — Separação de `border.default` (decorativa) e `border.control` (funcional) (Aceita — Implementada em 0.5.0)
 - **ADR-010** — Remoção de `foundation.color.white` e `foundation.color.black` puros (Aceita — Implementada em 0.5.0)
 - **ADR-011** — Reestruturação do naming de tokens semânticos de cor (Aceita — Implementada em 0.5.0)
+- **ADR-012** — Tokens de line-height e letter-spacing divergem por design entre Figma e JSON (Aceita)

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,7 +63,7 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T22:52:19.361Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T23:19:17.897Z</div>
       <div><strong>Tokens JSON:</strong> 632</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.15 -->v0.5.15</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.16 -->v0.5.16</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",

--- a/scripts/lib/figma-dtcg.mjs
+++ b/scripts/lib/figma-dtcg.mjs
@@ -317,15 +317,44 @@ function isCssOnlyToken(token) {
   return CSS_ONLY_TOKENS.some((rx) => rx.test(token));
 }
 
+// ADR-012: tokens de line-height e letter-spacing têm representação divergente
+// por design — Figma usa PX (limite da Plugin API pra lineHeight/letterSpacing
+// em text styles); JSON usa ratio unitless / rem / em (requisito CSS + WCAG
+// 1.4.4 "Resize Text"). Não sincronizam entre si; cada lado é canônico no seu
+// contexto. Vão pra categoria BY_DESIGN (informativa, 0 drift).
+const FIGMA_ONLY_PATHS = [
+  /^foundation\.typography\.font\.line-height\./,      // px absoluto nos text styles Figma
+  /^foundation\.typography\.font\.letter-spacing\./,   // px absoluto
+];
+const JSON_ONLY_PATHS = [
+  /^foundation\.typography\.line\.height\./,           // ratio / rem no CSS gerado
+  /^foundation\.typography\.letter\.spacing\./,        // em no CSS gerado
+];
+
+function isFigmaOnlyToken(token) {
+  return FIGMA_ONLY_PATHS.some((rx) => rx.test(token));
+}
+function isJsonOnlyToken(token) {
+  return JSON_ONLY_PATHS.some((rx) => rx.test(token));
+}
+
 /**
  * Compara expected (Figma) vs actual (JSON). Retorna:
- *   { VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA, CSS_ONLY }
- * VALUE_DRIFT é aplicável em --write.
- * CSS_ONLY é informativo — tokens que têm representação rica no JSON (stack,
- * unidade rem, weight numérico) que o Figma não representa bem. Não aplicar.
+ *   { VALUE_DRIFT, NEW_IN_FIGMA, MISSING_IN_FIGMA, CSS_ONLY, BY_DESIGN }
+ *
+ * - VALUE_DRIFT: mesmo nome, valor diferente. Aplicável em --write.
+ * - NEW_IN_FIGMA: Figma tem, JSON não. Ação manual.
+ * - MISSING_IN_FIGMA: JSON tem, Figma não. Ação manual.
+ * - CSS_ONLY (ADR-011 followup): mesmo token, representação diferente por
+ *   capacidade CSS (fallback stack, rem, weight numérico). Informativo.
+ * - BY_DESIGN (ADR-012): token existe só de um lado por escolha arquitetural
+ *   documentada (line-height/letter-spacing). Informativo, 0 drift.
  */
 export function compareStates(expected, actual) {
-  const diffs = { VALUE_DRIFT: [], NEW_IN_FIGMA: [], MISSING_IN_FIGMA: [], CSS_ONLY: [] };
+  const diffs = {
+    VALUE_DRIFT: [], NEW_IN_FIGMA: [], MISSING_IN_FIGMA: [],
+    CSS_ONLY: [], BY_DESIGN: [],
+  };
   const allFiles = new Set([...Object.keys(expected), ...Object.keys(actual)]);
   for (const file of allFiles) {
     const exp = expected[file] || {};
@@ -335,9 +364,19 @@ export function compareStates(expected, actual) {
       const e = exp[key];
       const a = act[key];
       if (e && !a) {
-        diffs.NEW_IN_FIGMA.push({ file, token: key, figma: e.$value });
+        // Token só no Figma
+        if (isFigmaOnlyToken(key)) {
+          diffs.BY_DESIGN.push({ file, token: key, side: 'figma-only', figma: e.$value });
+        } else {
+          diffs.NEW_IN_FIGMA.push({ file, token: key, figma: e.$value });
+        }
       } else if (!e && a) {
-        diffs.MISSING_IN_FIGMA.push({ file, token: key, json: a.$value });
+        // Token só no JSON
+        if (isJsonOnlyToken(key)) {
+          diffs.BY_DESIGN.push({ file, token: key, side: 'json-only', json: a.$value });
+        } else {
+          diffs.MISSING_IN_FIGMA.push({ file, token: key, json: a.$value });
+        }
       } else if (e && a) {
         if (normalizeForCompare(e.$value) !== normalizeForCompare(a.$value)) {
           if (isCssOnlyToken(key)) {

--- a/scripts/sync-tokens-from-figma.mjs
+++ b/scripts/sync-tokens-from-figma.mjs
@@ -29,6 +29,12 @@
  *   NEW_IN_FIGMA       Figma tem, JSON não. `--write` não cria — ação manual.
  *   MISSING_IN_FIGMA   JSON tem, Figma não. `--write` não deleta — ação manual.
  *   ALIAS_BROKEN       variável Figma aponta pra ID inexistente.
+ *   CSS_ONLY           token existe em ambos, mas representação diverge por
+ *                      capacidade CSS (font family stack, rem, weight numérico).
+ *                      Não aplica em `--write` (evita regressão CSS).
+ *   BY_DESIGN          token existe só em um lado por escolha arquitetural
+ *                      documentada (ADR-012 — line-height/letter-spacing em
+ *                      PX no Figma vs ratio/em no JSON). Informativo, não sync.
  *
  * Exit codes:
  *   0 — sem divergências ou --write bem sucedido.
@@ -86,6 +92,7 @@ function report(diffs, issues) {
   const total = diffs.VALUE_DRIFT.length + diffs.NEW_IN_FIGMA.length + diffs.MISSING_IN_FIGMA.length;
   const aliasBroken = issues.filter((i) => i.category === "ALIAS_BROKEN").length;
   const cssOnly = (diffs.CSS_ONLY || []).length;
+  const byDesign = (diffs.BY_DESIGN || []).length;
 
   console.log("");
   console.log("═══ sync-tokens-from-figma ═════════════════════════════");
@@ -93,7 +100,8 @@ function report(diffs, issues) {
   console.log(`NEW_IN_FIGMA     (Figma tem, JSON não):      ${diffs.NEW_IN_FIGMA.length}`);
   console.log(`MISSING_IN_FIGMA (JSON tem, Figma não):      ${diffs.MISSING_IN_FIGMA.length}`);
   console.log(`ALIAS_BROKEN     (Figma aponta pra órfão):   ${aliasBroken}`);
-  console.log(`CSS_ONLY         (informativo, não sync):    ${cssOnly}`);
+  console.log(`CSS_ONLY         (repr. CSS-específica):     ${cssOnly}`);
+  console.log(`BY_DESIGN        (divergência arquit. ADR):  ${byDesign}`);
   console.log("═════════════════════════════════════════════════════════");
 
   const section = (title, items, format) => {
@@ -127,6 +135,13 @@ function report(diffs, issues) {
     "CSS_ONLY (representação CSS-específica — JSON preserva, Figma aproxima)",
     diffs.CSS_ONLY || [],
     (d) => `${d.token}\n    Figma: ${fmt(d.figma)}\n    JSON:  ${fmt(d.json)}`
+  );
+  section(
+    "BY_DESIGN (ADR-012 — divergência arquitetural line-height/letter-spacing)",
+    diffs.BY_DESIGN || [],
+    (d) => d.side === 'figma-only'
+      ? `${d.token} = ${fmt(d.figma)} (só no Figma, ${d.side})`
+      : `${d.token} = ${fmt(d.json)} (só no JSON, ${d.side})`
   );
 
   console.log("");


### PR DESCRIPTION
## Summary

Fecha **issue #23**. Formaliza via **ADR-012** que line-height e letter-spacing têm representação divergente por design entre Figma e JSON, e ajusta o sync pra não reportar essa divergência arquitetural como drift.

## Contexto (dados reais)

Auditoria do consumo atual:
- **Figma**: 24 de 28 text styles consomem \`typography/font/line-height/*\` e \`typography/font/letter-spacing/*\` via boundVariables (valores em PX — Plugin API não aceita outra coisa).
- **JSON**: \`foundation.typography.line.height.*\` consumido 20× em 8 componentes CSS como ratio unitless / rem. \`foundation.typography.letter.spacing.*\` reservado como API pública (0 consumos atuais, mas documentado).

Os dois lados são canônicos nos seus contextos. Unificar causa perda real:
- Unificar em PX → quebra WCAG 1.4.4 (Resize Text).
- Unificar em ratio/em → Plugin API do Figma não aceita.

## O que muda

**ADR-012** documenta a decisão, as alternativas consideradas, e a regra operacional ("sync não sincroniza esses tokens; cada lado evolui independentemente").

**\`scripts/lib/figma-dtcg.mjs\`** ganha:
\`\`\`js
const FIGMA_ONLY_PATHS = [/^foundation\.typography\.font\.line-height\./, /^foundation\.typography\.font\.letter-spacing\./];
const JSON_ONLY_PATHS  = [/^foundation\.typography\.line\.height\./,      /^foundation\.typography\.letter\.spacing\./];
\`\`\`
Tokens casando vão pra categoria \`BY_DESIGN\` em vez de \`NEW_IN_FIGMA\` / \`MISSING_IN_FIGMA\`.

**\`sync-tokens-from-figma.mjs\`** ganha contagem e seção \`BY_DESIGN\` com indicação de lado (\`figma-only\` / \`json-only\`).

**\`docs/process-figma-sync.md\`** tabela de categorias passa de 4 → 6 (inclui \`CSS_ONLY\` — que já existia desde 0.5.11 mas não estava documentado na tabela — e novo \`BY_DESIGN\`).

## Efeito no dry-run

Antes:
\`\`\`
VALUE_DRIFT      0
NEW_IN_FIGMA     23   ← falsos positivos
MISSING_IN_FIGMA 14   ← falsos positivos
CSS_ONLY          9
\`\`\`

Depois:
\`\`\`
VALUE_DRIFT      0
NEW_IN_FIGMA     0    ← limpo
MISSING_IN_FIGMA 0    ← limpo
CSS_ONLY          9
BY_DESIGN        37   ← informativo, 0 drift
\`\`\`

Exit code 0 quando só restam CSS_ONLY e BY_DESIGN.

## Diferença CSS_ONLY vs BY_DESIGN

| | CSS_ONLY | BY_DESIGN |
|---|---|---|
| Quando o token existe | nos dois lados | só em um lado |
| Por que diverge | capacidade CSS (stack, rem, weight numérico) | escolha arquitetural (PX vs ratio/em) |
| ADR | — (informal desde 0.5.11) | ADR-012 |
| Ação em \`--write\` | não aplica | não aplica |

## Test plan

- [x] \`node scripts/sync-tokens-from-figma.mjs\` exit 0, reporta 37 BY_DESIGN
- [x] \`npm run build:all\` passa
- [x] ADR-012 gerado em HTML via sync:docs
- [ ] Após merge: confirmar visualmente pós-deploy que a doc \`process-figma-sync.md\` mostra 6 categorias
- [ ] Fechar issue #23 com link pra este PR

## Referências

- Issue #23 (origem)
- ADR-003 revisada (Figma = autoridade de valor)
- ADR-001 (arquitetura de tokens)
- WCAG 2.2 §1.4.4 Resize Text
- CSS Values and Units Level 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)