### PR TITLE
fix(figma): bind 74 gaps raw em form controls + novo gap.2xs (0.5.17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules/
 # Figma snapshot gerado via MCP (sync Figma → JSON)
 .figma-snapshot.json
 .figma-snapshot.*.json
+
+# Dumps de revert de ações pontuais em Figma (issue #24.x)
+.figma-revert-*.json
+.figma-revert-*.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+## [0.5.17]
+
+### Adicionado
+- `semantic.space.gap.2xs` → `{foundation.spacing.0-5}` (2px). Gera `--ds-space-gap-2xs` no CSS. Cobre gaps muito compactos entre elementos (Label Row: label + asterisco required). Issue #24.1.
+- Variable correspondente em Figma (`space/gap/2xs` em Semantic collection, alias pra `spacing/0-5` nos modos Light/Dark).
+
+### Corrigido (Figma — form controls bindings)
+Fecha **issue #24.1**. Auditoria do Figma encontrou **75 nodes com `itemSpacing` raw** nos componentes Input Text, Select e Textarea. Aplicados 74 bindings (1 descartado — `Frame 1` de preview, fora de componente):
+
+- **63 Label Row @ 2px** → bind pra `semantic.space.gap.2xs` (token novo).
+- **5 Error Message @ 4px** (Input Text) → bind pra `semantic.space.gap.xs`.
+- **6 Error Message @ 6px** (Textarea + Select) → **padronizado para 4px** + bind pra `semantic.space.gap.xs`. Alinha com o padrão do Input Text (inconsistência histórica — mesma função visual, valores diferentes entre componentes da mesma família).
+
+Audit pós-fix: **0 `itemSpacing` raw** nos 3 componentes. Sync Figma↔JSON: **0 drift** (`VALUE_DRIFT=0, NEW_IN_FIGMA=0, MISSING_IN_FIGMA=0, ALIAS_BROKEN=0`).
+
+### Reversibilidade
+- `.figma-revert-24.1.json` (gitignored): dump do estado original de todos os 74 nodes com valores raw antes do fix.
+- `.figma-revert-24.1.mjs` (gitignored): script documentando como reverter (desfazer bindings + restaurar valores raw + opcionalmente remover `gap.2xs`).
+- Permite rollback completo se necessário.
+
+### Mudança visual
+Error Message de Textarea e Select fica **2px mais compacto** (6px → 4px). Alinhamento com Input Text — bug visual histórico corrigido.
+
 ## [0.5.16]
 
 ### Adicionado

--- a/css/tokens/generated/theme-dark.css
+++ b/css/tokens/generated/theme-dark.css
@@ -91,6 +91,7 @@
   --ds-space-inset-md: var(--ds-spacing-3);
   --ds-space-inset-lg: var(--ds-spacing-4);
   --ds-space-inset-xl: var(--ds-spacing-6);
+  --ds-space-gap-2xs: var(--ds-spacing-0-5); /** 2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1. */
   --ds-space-gap-xs: var(--ds-spacing-1);
   --ds-space-gap-sm: var(--ds-spacing-2);
   --ds-space-gap-md: var(--ds-spacing-3);

--- a/css/tokens/generated/theme-light.css
+++ b/css/tokens/generated/theme-light.css
@@ -92,6 +92,7 @@
   --ds-space-inset-md: var(--ds-spacing-3);
   --ds-space-inset-lg: var(--ds-spacing-4);
   --ds-space-inset-xl: var(--ds-spacing-6);
+  --ds-space-gap-2xs: var(--ds-spacing-0-5); /** 2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1. */
   --ds-space-gap-xs: var(--ds-spacing-1);
   --ds-space-gap-sm: var(--ds-spacing-2);
   --ds-space-gap-md: var(--ds-spacing-3);

--- a/docs/api/adrs.json
+++ b/docs/api/adrs.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T23:20:37.368Z",
-  "version": "0.5.16",
+  "generatedAt": "2026-04-21T23:54:25.931Z",
+  "version": "0.5.17",
   "count": 12,
   "adrs": [
     {

--- a/docs/api/components.json
+++ b/docs/api/components.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T23:20:37.368Z",
-  "version": "0.5.16",
+  "generatedAt": "2026-04-21T23:54:25.931Z",
+  "version": "0.5.17",
   "count": 18,
   "components": [
     {

--- a/docs/api/foundations.json
+++ b/docs/api/foundations.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-21T23:20:37.368Z",
-  "version": "0.5.16",
+  "generatedAt": "2026-04-21T23:54:25.931Z",
+  "version": "0.5.17",
   "count": 11,
   "foundations": [
     {

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-21T23:20:37.851Z",
+  "generatedAt": "2026-04-21T23:54:26.389Z",
   "totals": {
-    "jsonTokens": 632,
+    "jsonTokens": 634,
     "sharedTokens": 368,
-    "lightTokens": 132,
-    "darkTokens": 132,
+    "lightTokens": 133,
+    "darkTokens": 133,
     "errors": 0,
     "warnings": 0
   },

--- a/docs/api/tokens.json
+++ b/docs/api/tokens.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-21T23:20:37.368Z",
-  "version": "0.5.16",
+  "generatedAt": "2026-04-21T23:54:25.931Z",
+  "version": "0.5.17",
   "counts": {
     "foundation": 231,
-    "semanticLight": 132,
-    "semanticDark": 132,
+    "semanticLight": 133,
+    "semanticDark": 133,
     "component": 137
   },
   "foundation": {
@@ -1433,6 +1433,11 @@
         "value": "{foundation.spacing.6}",
         "type": "dimension"
       },
+      "semantic.space.gap.2xs": {
+        "value": "{foundation.spacing.0-5}",
+        "type": "dimension",
+        "description": "2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1."
+      },
       "semantic.space.gap.xs": {
         "value": "{foundation.spacing.1}",
         "type": "dimension"
@@ -2006,6 +2011,11 @@
       "semantic.space.inset.xl": {
         "value": "{foundation.spacing.6}",
         "type": "dimension"
+      },
+      "semantic.space.gap.2xs": {
+        "value": "{foundation.spacing.0-5}",
+        "type": "dimension",
+        "description": "2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1."
       },
       "semantic.space.gap.xs": {
         "value": "{foundation.spacing.1}",

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,28 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h2>[0.5.17]</h2>
+<h3>Adicionado</h3>
+<ul>
+<li><code>semantic.space.gap.2xs</code> → <code>{foundation.spacing.0-5}</code> (2px). Gera <code>--ds-space-gap-2xs</code> no CSS. Cobre gaps muito compactos entre elementos (Label Row: label + asterisco required). Issue #24.1.</li>
+<li>Variable correspondente em Figma (<code>space/gap/2xs</code> em Semantic collection, alias pra <code>spacing/0-5</code> nos modos Light/Dark).</li>
+</ul>
+<h3>Corrigido (Figma — form controls bindings)</h3>
+<p>Fecha <strong>issue #24.1</strong>. Auditoria do Figma encontrou <strong>75 nodes com <code>itemSpacing</code> raw</strong> nos componentes Input Text, Select e Textarea. Aplicados 74 bindings (1 descartado — <code>Frame 1</code> de preview, fora de componente):</p>
+<ul>
+<li><strong>63 Label Row @ 2px</strong> → bind pra <code>semantic.space.gap.2xs</code> (token novo).</li>
+<li><strong>5 Error Message @ 4px</strong> (Input Text) → bind pra <code>semantic.space.gap.xs</code>.</li>
+<li><strong>6 Error Message @ 6px</strong> (Textarea + Select) → <strong>padronizado para 4px</strong> + bind pra <code>semantic.space.gap.xs</code>. Alinha com o padrão do Input Text (inconsistência histórica — mesma função visual, valores diferentes entre componentes da mesma família).</li>
+</ul>
+<p>Audit pós-fix: <strong>0 <code>itemSpacing</code> raw</strong> nos 3 componentes. Sync Figma↔JSON: <strong>0 drift</strong> (<code>VALUE_DRIFT=0, NEW_IN_FIGMA=0, MISSING_IN_FIGMA=0, ALIAS_BROKEN=0</code>).</p>
+<h3>Reversibilidade</h3>
+<ul>
+<li><code>.figma-revert-24.1.json</code> (gitignored): dump do estado original de todos os 74 nodes com valores raw antes do fix.</li>
+<li><code>.figma-revert-24.1.mjs</code> (gitignored): script documentando como reverter (desfazer bindings + restaurar valores raw + opcionalmente remover <code>gap.2xs</code>).</li>
+<li>Permite rollback completo se necessário.</li>
+</ul>
+<h3>Mudança visual</h3>
+<p>Error Message de Textarea e Select fica <strong>2px mais compacto</strong> (6px → 4px). Alinhamento com Input Text — bug visual histórico corrigido.</p>
 <h2>[0.5.16]</h2>
 <h3>Adicionado</h3>
 <ul>

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -2,7 +2,7 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.16**
+> Versão atual: **0.5.17**
 
 ## Status geral
 
@@ -40,8 +40,8 @@
 | Coleção | Tokens | Status |
 |---------|--------|--------|
 | Foundation | 231 | 🟢 |
-| Semantic (light) | 132 | 🟢 |
-| Semantic (dark) | 132 | 🟢 |
+| Semantic (light) | 133 | 🟢 |
+| Semantic (dark) | 133 | 🟢 |
 | Component | 137 | 🟢 |
 
 ## Pipeline

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Design System Core — conteúdo consolidado
 
-> Versão 0.5.16. Arquivo destinado a consumo por LLMs que precisem
+> Versão 0.5.17. Arquivo destinado a consumo por LLMs que precisem
 > do design system inteiro em uma requisição. Inclui README, CONTRIBUTING,
 > CLAUDE.md, CHANGELOG, todos os MDs em docs/, todos os ADRs e um resumo
 > dos tokens. Páginas HTML-only (componentes, foundations) estão referenciadas
@@ -351,6 +351,29 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.
 Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em `docs/process-versioning.html`.
 
 ## [Não publicado]
+
+## [0.5.17]
+
+### Adicionado
+- `semantic.space.gap.2xs` → `{foundation.spacing.0-5}` (2px). Gera `--ds-space-gap-2xs` no CSS. Cobre gaps muito compactos entre elementos (Label Row: label + asterisco required). Issue #24.1.
+- Variable correspondente em Figma (`space/gap/2xs` em Semantic collection, alias pra `spacing/0-5` nos modos Light/Dark).
+
+### Corrigido (Figma — form controls bindings)
+Fecha **issue #24.1**. Auditoria do Figma encontrou **75 nodes com `itemSpacing` raw** nos componentes Input Text, Select e Textarea. Aplicados 74 bindings (1 descartado — `Frame 1` de preview, fora de componente):
+
+- **63 Label Row @ 2px** → bind pra `semantic.space.gap.2xs` (token novo).
+- **5 Error Message @ 4px** (Input Text) → bind pra `semantic.space.gap.xs`.
+- **6 Error Message @ 6px** (Textarea + Select) → **padronizado para 4px** + bind pra `semantic.space.gap.xs`. Alinha com o padrão do Input Text (inconsistência histórica — mesma função visual, valores diferentes entre componentes da mesma família).
+
+Audit pós-fix: **0 `itemSpacing` raw** nos 3 componentes. Sync Figma↔JSON: **0 drift** (`VALUE_DRIFT=0, NEW_IN_FIGMA=0, MISSING_IN_FIGMA=0, ALIAS_BROKEN=0`).
+
+### Reversibilidade
+- `.figma-revert-24.1.json` (gitignored): dump do estado original de todos os 74 nodes com valores raw antes do fix.
+- `.figma-revert-24.1.mjs` (gitignored): script documentando como reverter (desfazer bindings + restaurar valores raw + opcionalmente remover `gap.2xs`).
+- Permite rollback completo se necessário.
+
+### Mudança visual
+Error Message de Textarea e Select fica **2px mais compacto** (6px → 4px). Alinhamento com Input Text — bug visual histórico corrigido.
 
 ## [0.5.16]
 
@@ -924,7 +947,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.16**
+> Versão atual: **0.5.17**
 
 ## Status geral
 
@@ -962,8 +985,8 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 | Coleção | Tokens | Status |
 |---------|--------|--------|
 | Foundation | 231 | 🟢 |
-| Semantic (light) | 132 | 🟢 |
-| Semantic (dark) | 132 | 🟢 |
+| Semantic (light) | 133 | 🟢 |
+| Semantic (dark) | 133 | 🟢 |
 | Component | 137 | 🟢 |
 
 ## Pipeline
@@ -1547,24 +1570,24 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.16**
+> Versão atual: **0.5.17**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.16 |
+| Versão | 0.5.17 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
-| Paridade light/dark | ✅ 132 tokens em ambos os modos |
+| Paridade light/dark | ✅ 133 tokens em ambos os modos |
 
 ## Camadas
 
 | Camada | Tokens | Arquivos |
 |--------|--------|----------|
 | Foundation | **231** | 10 |
-| Semantic | **132 × 2 modos** | light.json + dark.json |
+| Semantic | **133 × 2 modos** | light.json + dark.json |
 | Component | **137** | 11 |
 
 ## Foundation (231 tokens)
@@ -1582,7 +1605,7 @@ Se uma decisão arquitetural não está registrada como ADR, ela não foi tomada
 | `typography.json` | 35 |
 | `z-index.json` | 6 |
 
-## Semantic (132 tokens × 2 modos)
+## Semantic (133 tokens × 2 modos)
 
 Categorias raiz em light.json:
 
@@ -3085,6 +3108,6 @@ Verificação automática de coerência Figma ↔ JSON ↔ CSS: `scripts/tokens-
 
 ═══════════════════════════════════════════════════════════
 
-Gerado por scripts/build-llms.mjs em 2026-04-21T23:20:37.609Z
-Versão: 0.5.16
+Gerado por scripts/build-llms.mjs em 2026-04-21T23:54:26.159Z
+Versão: 0.5.17
 Site: https://uxindesign.github.io/design-system-core/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Design System Core
 
-> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.16. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
+> Design system white-label em CSS puro com tokens DTCG em JSON, 18 componentes, modos light/dark, três temas (Default, Ocean, Forest). Versão atual: 0.5.17. Enquanto não houver release oficial 1.0, o projeto fica em 0.x.
 
 Repositório: https://github.com/uxindesign/design-system-core
 Site: https://uxindesign.github.io/design-system-core/
@@ -90,4 +90,4 @@ Arquivo completo para LLMs: https://uxindesign.github.io/design-system-core/docs
 
 ---
 
-Gerado por `scripts/build-llms.mjs` em 2026-04-21T23:20:37.609Z.
+Gerado por `scripts/build-llms.mjs` em 2026-04-21T23:54:26.159Z.

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -2,24 +2,24 @@
 
 > Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
-> Versão atual: **0.5.16**
+> Versão atual: **0.5.17**
 
 ## Estado atual
 
 | Aspecto | Valor |
 |---------|-------|
-| Versão | 0.5.16 |
+| Versão | 0.5.17 |
 | Formato canônico | JSON (DTCG) em `tokens/` |
 | CSS gerado | Style Dictionary → `css/tokens/generated/` |
 | Pipeline | ✅ index.css importa apenas generated/ |
-| Paridade light/dark | ✅ 132 tokens em ambos os modos |
+| Paridade light/dark | ✅ 133 tokens em ambos os modos |
 
 ## Camadas
 
 | Camada | Tokens | Arquivos |
 |--------|--------|----------|
 | Foundation | **231** | 10 |
-| Semantic | **132 × 2 modos** | light.json + dark.json |
+| Semantic | **133 × 2 modos** | light.json + dark.json |
 | Component | **137** | 11 |
 
 ## Foundation (231 tokens)
@@ -37,7 +37,7 @@
 | `typography.json` | 35 |
 | `z-index.json` | 6 |
 
-## Semantic (132 tokens × 2 modos)
+## Semantic (133 tokens × 2 modos)
 
 Categorias raiz em light.json:
 

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -63,8 +63,8 @@
   <div class="ds-section">
     <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-21T23:20:37.851Z</div>
-      <div><strong>Tokens JSON:</strong> 632</div>
+      <div><strong>Última verificação:</strong> 2026-04-21T23:54:26.389Z</div>
+      <div><strong>Tokens JSON:</strong> 634</div>
       <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
   <!-- Hero -->
   <div class="ds-section">
-    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.16 -->v0.5.16</span></h1>
+    <h1 class="ds-section__title">Design System <span style="display:inline-block;font-size:0.45em;vertical-align:middle;padding:var(--ds-spacing-1) var(--ds-spacing-2);border-radius:var(--ds-radius-sm);background:var(--ds-brand-subtle);color:var(--ds-brand-content-default);font-family:var(--ds-font-family-mono);font-weight:var(--ds-font-weight-semibold);margin-left:var(--ds-spacing-2);"><!-- VERSION:0.5.17 -->v0.5.17</span></h1>
     <p class="ds-section__subtitle">
       <span data-lang="pt">Um design system CSS white-label com 300+ tokens, 19 componentes, suporte multi-tema e acessibilidade WCAG 2.2.</span>
       <span data-lang="en">A white-label CSS design system with 300+ tokens, 19 components, multi-theme support, and WCAG 2.2 accessibility.</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxin/design-system-core",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "White-label CSS design system with semantic tokens, 18 components, and light/dark mode support",
   "main": "css/design-system.css",
   "style": "css/design-system.css",

--- a/tokens/semantic/dark.json
+++ b/tokens/semantic/dark.json
@@ -472,6 +472,11 @@
         }
       },
       "gap": {
+        "2xs": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.0-5}",
+          "$description": "2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1."
+        },
         "xs": {
           "$type": "dimension",
           "$value": "{foundation.spacing.1}"

--- a/tokens/semantic/light.json
+++ b/tokens/semantic/light.json
@@ -498,6 +498,11 @@
         }
       },
       "gap": {
+        "2xs": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.0-5}",
+          "$description": "2px. Gap muito compacto — usado em Label Row (label + asterisco required) de form controls. Issue #24.1."
+        },
         "xs": {
           "$type": "dimension",
           "$value": "{foundation.spacing.1}"


### PR DESCRIPTION
## Summary

Piloto do **issue #24** (auditoria Figma bindings por componente). Primeiro escopo: **form controls — Input Text, Select, Textarea** — 75 nodes com \`itemSpacing\` raw detectados no audit.

Aplicado escopo **A + A1** (padronização): criar token novo pra 2px e alinhar 6px com 4px pra resolver inconsistência histórica.

## Antes

Audit panorâmico (#24):
\`\`\`
Input Text:  21 gap unbound
Select:      21 gap unbound
Textarea:    21 gap unbound (+3 radius, +2 padding — fora deste PR)
──────────────────────────────────
Total escopo: 75 nodes com itemSpacing raw
\`\`\`

Distribuição por valor:
- **63 Label Row @ 2px** — sem token semantic de gap pra 2px
- **5 Error Message @ 4px** (Input Text) — token \`gap.xs\` existente mas não bindado
- **6 Error Message @ 6px** (Textarea, Select) — **inconsistência**: mesma função, valor diferente da família
- **1 Frame 1 @ 48px** — preview, fora de componente

## Mudanças

**Token novo (JSON + Figma):**
- \`semantic.space.gap.2xs\` → \`{foundation.spacing.0-5}\` (2px).
- Gera \`--ds-space-gap-2xs\` no CSS.
- Figma: \`space/gap/2xs\` em coleção Semantic, alias pra \`spacing/0-5\` nos modos Light/Dark.

**Bindings aplicados (74 nodes):**
| Grupo | Antes | Depois | Token |
|---|---|---|---|
| 63 Label Row | 2px raw | 2px bindado | \`gap.2xs\` (novo) |
| 5 Error Message (Input Text) | 4px raw | 4px bindado | \`gap.xs\` (existente) |
| 6 Error Message (Textarea, Select) | **6px raw** | **4px bindado** | \`gap.xs\` (alinhado) |

**Mudança visual**: Error Message de Textarea e Select fica **2px mais compacto** (6→4px). Alinhamento com o padrão já existente no Input Text. Bug visual histórico corrigido.

## Validação

- [x] \`npm run build:all\` passa (0 erros, 0 avisos).
- [x] Audit pós-fix via \`use_figma\`: **0 \`itemSpacing\` raw** em Input Text / Select / Textarea.
- [x] Sync Figma↔JSON dry-run:
  \`\`\`
  VALUE_DRIFT=0, NEW_IN_FIGMA=0, MISSING_IN_FIGMA=0, ALIAS_BROKEN=0
  CSS_ONLY=9 (ADR-011 f/u), BY_DESIGN=37 (ADR-012)
  \`\`\`
- [ ] Verificar visualmente pós-deploy no site que Error Message fica compacto.

## Reversibilidade

Arquivos gitignored locais pra rollback se necessário:

- \`.figma-revert-24.1.json\`: dump do estado raw dos 74 nodes (nodeId, nodeName, parent, itemSpacing original).
- \`.figma-revert-24.1.mjs\`: script documentando como reverter (desfazer bindings + restaurar valores raw + opcionalmente remover \`gap.2xs\`).

Se precisar reverter após merge: rodar o script via \`use_figma\` em sessão Claude Code. Ambos os arquivos ficam no filesystem local mesmo após merge (gitignored); backup separado se for operar de outra máquina.

## Próximos sub-PRs (issue #24)

Conforme [proposta original](https://github.com/uxindesign/design-system-core/issues/24):

- **#24.2** — Textarea/Select radius & padding residuais (8 casos pós-#24.1)
- **#24.3** — Card / Modal effects (investigar se são decorativos ou focus ring)
- **#24.4** — Toggle + Radio effects (depende de #24.3)
- **#24.5** — Checkbox completo (66 casos; o mais complexo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)