### PR TITLE
fix(components): #24.3 — Card/Modal elevation + Focus Ring bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Fecha **issue #24.3**. Três drifts entre Figma e o canônico (CSS + `docs/found
 
 - **Modal** (3 variants: Size=Small/Medium/Large): `effectStyleId` estava em `elevation/3` (shadow-lg, nível 3). Ajustado para `elevation/4` (shadow-xl, nível 4) — bate com `ds-modal { box-shadow: var(--ds-shadow-xl) }` e com a doc "Modais = nível 4".
 - **Effect styles `elevation/3` e `elevation/4`**: descrições trocadas. Agora `/3` = "Sidesheets, painéis flutuantes" e `/4` = "Modais, dialogs, overlays" — alinha com a doc.
-- **Focus Rings (78 nós)**: 72 em Button + 6 em Toggle com `strokeWeight=2` raw. Bindados em `focus/ring/width` (Figma Variable, alias pra `border/width/2`). API do Figma exigiu binding nos 4 campos individuais `strokeTopWeight/Right/Bottom/Left` — `setBoundVariable('strokeWeight', ...)` falha silenciosamente. Isso revela que **audits anteriores subestimaram cobertura**: checavam só `boundVariables.strokeWeight` (que nunca é usado). Issue #31 aberta pra atualizar `scripts/lib/figma-dtcg.mjs`.
+- **Focus Rings (78 nós)**: 72 em Button + 6 em Toggle com `strokeWeight=2` raw. Bindados em `focus/ring/width` (Figma Variable, alias pra `border/width/2`). API do Figma exigiu binding nos 4 campos individuais `strokeTopWeight/Right/Bottom/Left` — `setBoundVariable('strokeWeight', ...)` falha silenciosamente. Isso revela que **audits anteriores subestimaram cobertura**: checavam só `boundVariables.strokeWeight` (que nunca é usado). Issue #34 aberta pra atualizar `scripts/lib/figma-dtcg.mjs`.
 - **Card** (variante Style=Elevated): `effectStyleId` estava em `elevation/2` (shadow-md, nível 2). Ajustado para `elevation/1` (shadow-sm, nível 1) — bate com a doc "Cards, painéis, sticky headers = nível 1". CSS também atualizado: `.ds-card--elevated { box-shadow: var(--ds-shadow-sm) }` (era `shadow-md`).
 
 ### Mudança visual
@@ -27,9 +27,9 @@ Card `--elevated` fica com sombra **ligeiramente mais sutil** (shadow-md → sha
 Todos gitignored.
 
 ### Backlog / sub-issues
-- **#31** — Atualizar `scripts/lib/figma-dtcg.mjs`: auditar `strokeWeight` via `strokeTopWeight`/etc. em vez de `strokeWeight` top-level. Afeta detecção de cobertura em audits futuros.
 - **#32** — Refactor Card API no Figma: properties `Elevated` (BOOLEAN) e `Interactive` (BOOLEAN) desacopladas de `Style`, com `State` variant quando `Interactive=true`. Breaking change em consumidores Figma.
 - **#33** — Divergência entre `elevation/1` / `elevation/2` no Figma e `shadow-sm` / `shadow-md` no JSON (valores diferentes em radius, spread e alpha). Precisa decisão: Figma é fonte → atualizar JSON; ou JSON é fonte → atualizar Figma. ADR-003 indica **Figma como fonte canônica de valor** — mas os valores do JSON já estão em produção no CSS.
+- **#34** — Atualizar `scripts/lib/figma-dtcg.mjs`: auditar `strokeWeight` via `strokeTopWeight`/etc. em vez de `strokeWeight` top-level. Afeta detecção de cobertura em audits futuros.
 
 ## [0.5.17]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+### Corrigido (Figma — elevation e focus rings)
+Fecha **issue #24.3**. Três drifts entre Figma e o canônico (CSS + `docs/foundations-elevation.html`):
+
+- **Modal** (3 variants: Size=Small/Medium/Large): `effectStyleId` estava em `elevation/3` (shadow-lg, nível 3). Ajustado para `elevation/4` (shadow-xl, nível 4) — bate com `ds-modal { box-shadow: var(--ds-shadow-xl) }` e com a doc "Modais = nível 4".
+- **Effect styles `elevation/3` e `elevation/4`**: descrições trocadas. Agora `/3` = "Sidesheets, painéis flutuantes" e `/4` = "Modais, dialogs, overlays" — alinha com a doc.
+- **Focus Rings (78 nós)**: 72 em Button + 6 em Toggle com `strokeWeight=2` raw. Bindados em `focus/ring/width` (Figma Variable, alias pra `border/width/2`). API do Figma exigiu binding nos 4 campos individuais `strokeTopWeight/Right/Bottom/Left` — `setBoundVariable('strokeWeight', ...)` falha silenciosamente. Isso revela que **audits anteriores subestimaram cobertura**: checavam só `boundVariables.strokeWeight` (que nunca é usado). Issue #31 aberta pra atualizar `scripts/lib/figma-dtcg.mjs`.
+- **Card** (variante Style=Elevated): `effectStyleId` estava em `elevation/2` (shadow-md, nível 2). Ajustado para `elevation/1` (shadow-sm, nível 1) — bate com a doc "Cards, painéis, sticky headers = nível 1". CSS também atualizado: `.ds-card--elevated { box-shadow: var(--ds-shadow-sm) }` (era `shadow-md`).
+
+### Mudança visual
+Card `--elevated` fica com sombra **ligeiramente mais sutil** (shadow-md → shadow-sm). Modal fica com sombra **mais pronunciada** (shadow-lg → shadow-xl) — o CSS já usava shadow-xl, o Figma é que estava desalinhado.
+
+### Reversibilidade
+- `.figma-revert-24.3.1.{json,mjs}` — Modal (restaura elevation/3 + descrições).
+- `.figma-revert-24.3.2.{json,mjs}` — Focus Rings (remove bindings dos 78 nós).
+- `.figma-revert-24.3.3.json` — Card elevated (restaura elevation/2).
+
+Todos gitignored.
+
+### Backlog / sub-issues
+- **#31** — Atualizar `scripts/lib/figma-dtcg.mjs`: auditar `strokeWeight` via `strokeTopWeight`/etc. em vez de `strokeWeight` top-level. Afeta detecção de cobertura em audits futuros.
+- **#32** — Refactor Card API no Figma: properties `Elevated` (BOOLEAN) e `Interactive` (BOOLEAN) desacopladas de `Style`, com `State` variant quando `Interactive=true`. Breaking change em consumidores Figma.
+- **#33** — Divergência entre `elevation/1` / `elevation/2` no Figma e `shadow-sm` / `shadow-md` no JSON (valores diferentes em radius, spread e alpha). Precisa decisão: Figma é fonte → atualizar JSON; ou JSON é fonte → atualizar Figma. ADR-003 indica **Figma como fonte canônica de valor** — mas os valores do JSON já estão em produção no CSS.
+
 ## [0.5.17]
 
 ### Adicionado

--- a/css/components/card.css
+++ b/css/components/card.css
@@ -48,7 +48,7 @@
   border: var(--ds-border-width-1) solid var(--ds-border-default);
 }
 
-/* Elevated — shadow, no border */
+/* Elevated — shadow, no border (elevation level 1 per docs/foundations-elevation.html) */
 .ds-card--elevated {
-  box-shadow: var(--ds-shadow-md);
+  box-shadow: var(--ds-shadow-sm);
 }

--- a/docs/adr-index.md
+++ b/docs/adr-index.md
@@ -1,6 +1,6 @@
 # Índice de ADRs — Design System Core
 
-> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
+> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-22. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
 
 12 decisões registradas.

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -1,6 +1,6 @@
 # Inventário de componentes — Design System Core
 
-> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
+> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-22. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
 > Versão atual: **0.5.17**
 

--- a/docs/token-schema.md
+++ b/docs/token-schema.md
@@ -1,6 +1,6 @@
 # Token schema — Design System Core
 
-> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-21. Não editar manualmente.
+> Gerado automaticamente por `scripts/sync-docs.mjs` em 2026-04-22. Não editar manualmente.
 > Para regenerar: `npm run sync:docs`
 > Versão atual: **0.5.17**
 


### PR DESCRIPTION
## Summary

Alinha o Figma com o canônico (CSS + `docs/foundations-elevation.html`) em três pontos:

1. **Modal**: `effectStyleId` das 3 variantes (Small/Medium/Large) de `elevation/3` → `elevation/4`. CSS já usava `--ds-shadow-xl` (nível 4); era o Figma que estava desalinhado.
2. **Effect styles**: descrições de `elevation/3` e `/4` trocadas (hoje `/3` dizia "Modals" mas é nível 3 = Sidesheets). Reescritas.
3. **Focus Rings**: 78 nodes (72 Button + 6 Toggle) com `strokeWeight=2` raw bindados a `focus/ring/width`. API do Figma exigiu binding nos 4 campos `strokeTopWeight/Right/Bottom/Left` — `setBoundVariable('strokeWeight', ...)` falha silenciosamente.
4. **Card**: `Style=Elevated` muda de `elevation/2` (shadow-md) → `elevation/1` (shadow-sm, nível 1). CSS `.ds-card--elevated` também atualizado.

Issue #24.3 fechada.

## Mudança visual
- **Card elevated**: sombra mais sutil (shadow-md → shadow-sm)
- **Modal**: sombra mais forte (era shadow-lg no Figma, agora shadow-xl — alinha com CSS)

## Reversibilidade

Três dumps gitignored:
- `.figma-revert-24.3.1.{json,mjs}` — Modal
- `.figma-revert-24.3.2.{json,mjs}` — Focus Rings
- `.figma-revert-24.3.3.json` — Card

## Sub-issues abertas

- **#31** — Atualizar `scripts/lib/figma-dtcg.mjs` para auditar `strokeWeight` via `strokeTopWeight/Right/Bottom/Left` (não `strokeWeight` top-level). Audits anteriores subestimaram cobertura real.
- **#32** — Refactor Card API no Figma: properties `Interactive` e `Elevated` desacopladas de `Style`, com `State` variant quando `Interactive=true`. Breaking no Figma.
- **#33** — Divergência entre `elevation/1` / `elevation/2` (Figma) e `shadow-sm` / `shadow-md` (JSON) em radius, spread e alpha. Precisa decisão de fonte de verdade.

## Test plan

- [ ] Verificar visualmente o Modal no Figma (sombra mais marcada) e no site (sem mudança — CSS já usava shadow-xl).
- [ ] Verificar visualmente o Card elevated (mais sutil) tanto no Figma quanto no site.
- [ ] Checar Focus Ring em Button hover: valor continua 2px (comportamento igual, só agora é via variable).
- [ ] `npm run verify:tokens` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)