### PR TITLE
feat(tokens): Fases 2+3 ADR-013 — rebind 3479 bindings + converter 50 raw values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na
 
 ## [Não publicado]
 
+### Concluído (Fases 2 e 3 — rebind + conversão de raw values)
+
+**Fase 2**: Todos os 3.479 bindings Foundation nos 51 componentes Figma rebindados pra Semantic. Divididos em 4 passes:
+- Pass 1 — Icons (30 componentes, 60 rebinds — border/width/1 + font-family/weight/letter-spacing)
+- Pass 2a — Global typography em todos componentes (2.759 rebinds — font-family, font-weight, letter-spacing, border-width)
+- Pass 2b — font-size/line-height em não-controles → body.* (268 rebinds)
+- Pass 2c — font-size/line-height em controles → control.*/body.* contextual (210 rebinds)
+- Pass 3 — cleanup com IDs corrigidos (2.073 rebinds complementares)
+- Text styles — 28 text styles locais rebindados pra Semantic (98 rebinds). Isso destravou os nodes filhos que herdavam Foundation via style.
+
+Post-audit: **0 Foundation bindings remanescentes em qualquer componente Figma**. Regra ADR-013 cumprida no lado do Figma.
+
+**Fase 3**: Das 60 variáveis raw na collection Component Figma, **50 convertidas em aliases** (Foundation.* ou Semantic.*). Exemplos:
+- `avatar/size/sm` (32) → `{foundation.spacing.8}`
+- `checkbox/border-radius` (4) → `{foundation.radius.sm}`
+- `modal/border-radius` (16) → `{foundation.radius.xl}`
+- `checkbox/min-target-size` (44) → `{semantic.size.control.min-target}` — reaproveita alias semântico existente
+- `radio/font-size`, `toggle/font-size`, etc. (14) → `{foundation.typography.font.size.sm}`
+
+**10 vars permanecem raw** como exceção explícita (ADR-013 permite quando não há equivalente Foundation): `modal/max-width/{sm,md,lg}` (400/520/640), `textarea/min-height/{sm,lg}` (68/112), `skeleton/rect-height` (120), `spinner/stroke-width/{sm,lg}` (1.5/3), `toggle/thumb-size/lg` (18), `checkbox/check-width/md` (5). Todos valores sem ponto correspondente na escala Foundation.
+
+Pós-sync: `verify:tokens` — **0 errors, 0 warnings**. Figma ↔ JSON ↔ CSS totalmente sincronizados.
+
 ### Adicionado (Fase 1 — expansão Semantic typography)
 
 20 variáveis novas em `semantic.typography.body.*` no Figma e JSON, todas aliasando Foundation. Preparação pra Fase 2 (rebind dos 3.479 bindings Foundation em componentes Figma).

--- a/css/tokens/generated/component.css
+++ b/css/tokens/generated/component.css
@@ -3,66 +3,63 @@
  */
 
 :root {
-  --ds-avatar-size-sm: 2rem; /** 32px */
-  --ds-avatar-size-md: 2.5rem; /** 40px */
-  --ds-avatar-size-lg: 3.5rem; /** 56px */
-  --ds-avatar-font-size-sm: 0.75rem; /** 12px initials */
-  --ds-avatar-font-size-md: 0.875rem; /** 14px initials */
-  --ds-avatar-font-size-lg: 1.125rem; /** 18px initials */
-  --ds-avatar-icon-size-sm: 1rem; /** 16px */
-  --ds-avatar-icon-size-md: 1.25rem; /** 20px */
-  --ds-avatar-icon-size-lg: 1.75rem; /** 28px */
-  --ds-checkbox-control-size-sm: 1rem; /** 16px */
-  --ds-checkbox-control-size-md: 1.25rem; /** 20px */
-  --ds-checkbox-control-size-lg: 1.5rem; /** 24px */
-  --ds-checkbox-check-width-sm: 4px;
   --ds-checkbox-check-width-md: 5px;
-  --ds-checkbox-check-width-lg: 6px;
-  --ds-checkbox-check-height-sm: 8px;
-  --ds-checkbox-check-height-md: 10px;
-  --ds-checkbox-check-height-lg: 12px;
-  --ds-checkbox-min-target-size: 2.75rem; /** 44px — WCAG 2.5.5 */
-  --ds-checkbox-font-size: 0.875rem; /** 14px label */
   --ds-modal-max-width-sm: 25rem; /** 400px */
   --ds-modal-max-width-md: 32.5rem; /** 520px */
   --ds-modal-max-width-lg: 40rem; /** 640px */
-  --ds-radio-control-size-sm: 1rem; /** 16px */
-  --ds-radio-control-size-md: 1.25rem; /** 20px */
-  --ds-radio-control-size-lg: 1.5rem; /** 24px */
-  --ds-radio-dot-size-sm: 6px;
-  --ds-radio-dot-size-md: 8px;
-  --ds-radio-dot-size-lg: 10px;
-  --ds-radio-min-target-size: 2.75rem; /** 44px — WCAG 2.5.5 */
-  --ds-radio-font-size: 0.875rem; /** 14px label */
-  --ds-select-arrow-size: 1rem; /** 16px */
-  --ds-select-arrow-offset-sm: 0.5rem; /** 8px from right edge */
-  --ds-select-arrow-offset-md: 0.75rem; /** 12px */
-  --ds-select-arrow-offset-lg: 1rem; /** 16px */
-  --ds-skeleton-text-height: 1rem; /** 16px line placeholder */
-  --ds-skeleton-circle-size: 2.5rem; /** 40px avatar placeholder */
   --ds-skeleton-rect-height: 7.5rem; /** 120px image/card placeholder */
-  --ds-spinner-size-sm: 1rem; /** 16px */
-  --ds-spinner-size-md: 1.5rem; /** 24px */
-  --ds-spinner-size-lg: 2rem; /** 32px */
   --ds-spinner-stroke-width-sm: 1.5px;
-  --ds-spinner-stroke-width-md: 2px;
   --ds-spinner-stroke-width-lg: 3px;
   --ds-textarea-min-height-sm: 4.25rem; /** 68px */
-  --ds-textarea-min-height-md: 5rem; /** 80px */
   --ds-textarea-min-height-lg: 7rem; /** 112px */
-  --ds-toggle-track-width-sm: 1.75rem; /** 28px */
-  --ds-toggle-track-width-md: 2.25rem; /** 36px */
-  --ds-toggle-track-width-lg: 2.75rem; /** 44px */
-  --ds-toggle-track-height-sm: 1rem; /** 16px */
-  --ds-toggle-track-height-md: 1.25rem; /** 20px */
-  --ds-toggle-track-height-lg: 1.5rem; /** 24px */
-  --ds-toggle-thumb-size-sm: 0.625rem; /** 10px */
-  --ds-toggle-thumb-size-md: 0.875rem; /** 14px */
   --ds-toggle-thumb-size-lg: 1.125rem; /** 18px */
-  --ds-toggle-min-target-size: 2.75rem; /** 44px — WCAG 2.5.5 */
-  --ds-toggle-font-size: 0.875rem; /** 14px label */
+  --ds-avatar-size-sm: var(--ds-spacing-8); /** 32px */
+  --ds-avatar-size-md: var(--ds-spacing-10); /** 40px */
+  --ds-avatar-size-lg: var(--ds-spacing-14); /** 56px */
+  --ds-avatar-font-size-sm: var(--ds-font-size-xs); /** 12px initials */
+  --ds-avatar-font-size-md: var(--ds-font-size-sm); /** 14px initials */
+  --ds-avatar-font-size-lg: var(--ds-font-size-lg); /** 18px initials */
+  --ds-avatar-icon-size-sm: var(--ds-spacing-4); /** 16px */
+  --ds-avatar-icon-size-md: var(--ds-spacing-5); /** 20px */
+  --ds-avatar-icon-size-lg: var(--ds-spacing-7); /** 28px */
+  --ds-checkbox-control-size-sm: var(--ds-spacing-4); /** 16px */
+  --ds-checkbox-control-size-md: var(--ds-spacing-5); /** 20px */
+  --ds-checkbox-control-size-lg: var(--ds-spacing-6); /** 24px */
+  --ds-checkbox-check-width-sm: var(--ds-spacing-1);
+  --ds-checkbox-check-width-lg: var(--ds-spacing-1-5);
+  --ds-checkbox-check-height-sm: var(--ds-spacing-2);
+  --ds-checkbox-check-height-md: var(--ds-spacing-2-5);
+  --ds-checkbox-check-height-lg: var(--ds-spacing-3);
   --ds-checkbox-border-radius: var(--ds-radius-sm); /** 4px — smaller radius for compact control */
+  --ds-checkbox-font-size: var(--ds-font-size-sm); /** 14px label */
   --ds-modal-border-radius: var(--ds-radius-xl); /** 16px — xl radius for modal overlay */
+  --ds-radio-control-size-sm: var(--ds-spacing-4); /** 16px */
+  --ds-radio-control-size-md: var(--ds-spacing-5); /** 20px */
+  --ds-radio-control-size-lg: var(--ds-spacing-6); /** 24px */
+  --ds-radio-dot-size-sm: var(--ds-spacing-1-5);
+  --ds-radio-dot-size-md: var(--ds-spacing-2);
+  --ds-radio-dot-size-lg: var(--ds-spacing-2-5);
+  --ds-radio-font-size: var(--ds-font-size-sm); /** 14px label */
+  --ds-select-arrow-size: var(--ds-spacing-4); /** 16px */
+  --ds-select-arrow-offset-sm: var(--ds-spacing-2); /** 8px from right edge */
+  --ds-select-arrow-offset-md: var(--ds-spacing-3); /** 12px */
+  --ds-select-arrow-offset-lg: var(--ds-spacing-4); /** 16px */
+  --ds-skeleton-text-height: var(--ds-spacing-4); /** 16px line placeholder */
+  --ds-skeleton-circle-size: var(--ds-spacing-10); /** 40px avatar placeholder */
+  --ds-spinner-size-sm: var(--ds-spacing-4); /** 16px */
+  --ds-spinner-size-md: var(--ds-spacing-6); /** 24px */
+  --ds-spinner-size-lg: var(--ds-spacing-8); /** 32px */
+  --ds-spinner-stroke-width-md: var(--ds-spacing-0-5);
+  --ds-textarea-min-height-md: var(--ds-spacing-20); /** 80px */
+  --ds-toggle-track-width-sm: var(--ds-spacing-7); /** 28px */
+  --ds-toggle-track-width-md: var(--ds-spacing-9); /** 36px */
+  --ds-toggle-track-width-lg: var(--ds-spacing-11); /** 44px */
+  --ds-toggle-track-height-sm: var(--ds-spacing-4); /** 16px */
+  --ds-toggle-track-height-md: var(--ds-spacing-5); /** 20px */
+  --ds-toggle-track-height-lg: var(--ds-spacing-6); /** 24px */
+  --ds-toggle-thumb-size-sm: var(--ds-spacing-2-5); /** 10px */
+  --ds-toggle-thumb-size-md: var(--ds-spacing-3-5); /** 14px */
+  --ds-toggle-font-size: var(--ds-font-size-sm); /** 14px label */
   --ds-button-height-sm: var(--ds-size-control-sm); /** 32px */
   --ds-button-height-md: var(--ds-size-control-md); /** 40px */
   --ds-button-height-lg: var(--ds-size-control-lg); /** 48px */
@@ -90,6 +87,7 @@
   --ds-button-foreground-toned-disabled: var(--ds-content-disabled);
   --ds-checkbox-border-width: var(--ds-border-width-default);
   --ds-checkbox-gap: var(--ds-space-gap-sm); /** 8px between control and label */
+  --ds-checkbox-min-target-size: var(--ds-size-control-min-target); /** 44px — WCAG 2.5.5 */
   --ds-input-height-sm: var(--ds-size-control-sm); /** 32px */
   --ds-input-height-md: var(--ds-size-control-md); /** 40px */
   --ds-input-height-lg: var(--ds-size-control-lg); /** 48px */
@@ -112,6 +110,7 @@
   --ds-modal-header-gap: var(--ds-space-gap-sm); /** 8px between title and close */
   --ds-radio-border-width: var(--ds-border-width-default);
   --ds-radio-gap: var(--ds-space-gap-sm); /** 8px between control and label */
+  --ds-radio-min-target-size: var(--ds-size-control-min-target); /** 44px — WCAG 2.5.5 */
   --ds-select-height-sm: var(--ds-size-control-sm); /** 32px */
   --ds-select-height-md: var(--ds-size-control-md); /** 40px */
   --ds-select-height-lg: var(--ds-size-control-lg); /** 48px */
@@ -140,4 +139,5 @@
   --ds-textarea-font-size-md: var(--ds-control-font-size-md); /** 14px */
   --ds-textarea-font-size-lg: var(--ds-control-font-size-lg); /** 16px */
   --ds-toggle-gap: var(--ds-space-gap-sm); /** 8px between toggle and label */
+  --ds-toggle-min-target-size: var(--ds-size-control-min-target); /** 44px — WCAG 2.5.5 */
 }

--- a/docs/api/tokens-sync.json
+++ b/docs/api/tokens-sync.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-04-22T18:19:23.613Z",
+  "generatedAt": "2026-04-22T19:55:11.876Z",
   "totals": {
     "jsonTokens": 674,
     "sharedTokens": 368,
     "lightTokens": 153,
     "darkTokens": 153,
-    "errors": 2,
+    "errors": 0,
     "warnings": 0
   },
   "checks": {
@@ -17,46 +17,16 @@
       "summary": {
         "figmaVariableCount": 510,
         "figmaCollectionCount": 4,
-        "VALUE_DRIFT": 2,
+        "VALUE_DRIFT": 0,
         "NEEDS_SYNC": 0,
         "DRIFT_FROM_SOURCE": 0,
         "ALIAS_BROKEN": 0,
         "CSS_ONLY": 9,
         "BY_DESIGN": 53
       },
-      "divergences": [
-        {
-          "level": "error",
-          "category": "VALUE_DRIFT",
-          "token": "component.checkbox.border-radius",
-          "message": "valor difere: Figma=4 / JSON=\"{foundation.radius.sm}\"",
-          "figma": 4,
-          "json": "{foundation.radius.sm}"
-        },
-        {
-          "level": "error",
-          "category": "VALUE_DRIFT",
-          "token": "component.modal.border-radius",
-          "message": "valor difere: Figma=16 / JSON=\"{foundation.radius.xl}\"",
-          "figma": 16,
-          "json": "{foundation.radius.xl}"
-        }
-      ],
+      "divergences": [],
       "diffs": {
-        "VALUE_DRIFT": [
-          {
-            "file": "component/checkbox.json",
-            "token": "component.checkbox.border-radius",
-            "figma": 4,
-            "json": "{foundation.radius.sm}"
-          },
-          {
-            "file": "component/modal.json",
-            "token": "component.modal.border-radius",
-            "figma": 16,
-            "json": "{foundation.radius.xl}"
-          }
-        ],
+        "VALUE_DRIFT": [],
         "NEW_IN_FIGMA": [],
         "MISSING_IN_FIGMA": [],
         "CSS_ONLY": [

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -74,6 +74,20 @@
 <p>O formato é baseado em <a href="https://keepachangelog.com/pt-BR/1.1.0/">Keep a Changelog</a> e o versionamento segue <a href="https://semver.org/lang/pt-BR/">Semantic Versioning</a>.</p>
 <p>Enquanto o sistema não tiver um release oficial 1.0, todas as versões ficam na faixa 0.x. Regras de bump documentadas em <code>docs/process-versioning.html</code>.</p>
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
+<h3>Adicionado (Fase 1 — expansão Semantic typography)</h3>
+<p>20 variáveis novas em <code>semantic.typography.body.*</code> no Figma e JSON, todas aliasando Foundation. Preparação pra Fase 2 (rebind dos 3.479 bindings Foundation em componentes Figma).</p>
+<ul>
+<li><code>semantic.typography.body.font-family.sans</code> → <code>{foundation.typography.font.family.sans}</code></li>
+<li><code>semantic.typography.body.font-weight.{regular, medium, semibold, bold}</code> → foundation.weight.*</li>
+<li><code>semantic.typography.body.letter-spacing.{normal, tight}</code> → foundation.letter.spacing.*</li>
+<li><code>semantic.typography.body.font-size.{xs, sm, md, lg, xl, 2xl, 3xl}</code> → foundation.size.*</li>
+<li><code>semantic.typography.body.line-height.{xs, sm, md, xl, 2xl, 3xl}</code> → foundation ratios (ADR-012: Figma usa PX, JSON usa ratio unitless)</li>
+</ul>
+<p>CSS gerado: <code>--ds-body-font-family-sans</code>, <code>--ds-body-font-weight-*</code>, <code>--ds-body-letter-spacing-*</code>, <code>--ds-body-font-size-*</code>, <code>--ds-body-line-height-*</code>. Namespace <code>body</code> pareia com <code>control</code> (ADR-006) evitando colisão com Foundation (<code>--ds-font-family-sans</code> etc.).</p>
+<h3>Corrigido</h3>
+<ul>
+<li><code>scripts/lib/figma-dtcg.mjs</code> — <code>compareStates</code> estendido com <code>isDivergentAliasByDesign</code>: tokens Semantic/Component com aliases divergentes por design (Figma <code>font.line-height.*</code> px vs JSON <code>line.height.*</code> ratio) agora são <code>BY_DESIGN</code>, não <code>VALUE_DRIFT</code>. Extensão documentada em ADR-012.</li>
+</ul>
 <h3>Adicionado (arquitetura — ADR-013 e Token Registry)</h3>
 <p>Codificada a regra de camadas de consumo de tokens: <strong>Foundation nunca aparece em consumidor final</strong>. CSS de componente, bindings Figma e exemplos em docs só podem consumir Semantic ou Component. A regra sempre existiu implicitamente, mas agora está documentada formalmente e vai ganhar enforcement em CI nas próximas iterações.</p>
 <ul>

--- a/docs/token-registry.md
+++ b/docs/token-registry.md
@@ -228,27 +228,27 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `foundation.spacing.0` | dimension | — | ⚠️ TODO | 4 |
-| `foundation.spacing.0-5` | dimension | — | ⚠️ TODO | 8 |
-| `foundation.spacing.1` | dimension | — | ⚠️ TODO | 18 |
-| `foundation.spacing.1-5` | dimension | — | ⚠️ TODO | 3 |
-| `foundation.spacing.10` | dimension | — | ⚠️ TODO | 4 |
-| `foundation.spacing.11` | dimension | — | ⚠️ TODO | 4 |
+| `foundation.spacing.0` | dimension | — | ⚠️ TODO | 5 |
+| `foundation.spacing.0-5` | dimension | — | ⚠️ TODO | 10 |
+| `foundation.spacing.1` | dimension | — | ⚠️ TODO | 20 |
+| `foundation.spacing.1-5` | dimension | — | ⚠️ TODO | 6 |
+| `foundation.spacing.10` | dimension | — | ⚠️ TODO | 7 |
+| `foundation.spacing.11` | dimension | — | ⚠️ TODO | 6 |
 | `foundation.spacing.12` | dimension | — | ⚠️ TODO | 6 |
-| `foundation.spacing.14` | dimension | — | ⚠️ TODO | 0 |
+| `foundation.spacing.14` | dimension | — | ⚠️ TODO | 2 |
 | `foundation.spacing.16` | dimension | — | ⚠️ TODO | 4 |
-| `foundation.spacing.2` | dimension | — | ⚠️ TODO | 17 |
-| `foundation.spacing.2-5` | dimension | — | ⚠️ TODO | 4 |
-| `foundation.spacing.20` | dimension | — | ⚠️ TODO | 4 |
+| `foundation.spacing.2` | dimension | — | ⚠️ TODO | 21 |
+| `foundation.spacing.2-5` | dimension | — | ⚠️ TODO | 8 |
+| `foundation.spacing.20` | dimension | — | ⚠️ TODO | 6 |
 | `foundation.spacing.24` | dimension | — | ⚠️ TODO | 0 |
-| `foundation.spacing.3` | dimension | — | ⚠️ TODO | 14 |
-| `foundation.spacing.3-5` | dimension | — | ⚠️ TODO | 0 |
-| `foundation.spacing.4` | dimension | — | ⚠️ TODO | 20 |
-| `foundation.spacing.5` | dimension | — | ⚠️ TODO | 10 |
-| `foundation.spacing.6` | dimension | — | ⚠️ TODO | 12 |
-| `foundation.spacing.7` | dimension | — | ⚠️ TODO | 0 |
-| `foundation.spacing.8` | dimension | — | ⚠️ TODO | 7 |
-| `foundation.spacing.9` | dimension | — | ⚠️ TODO | 0 |
+| `foundation.spacing.3` | dimension | — | ⚠️ TODO | 17 |
+| `foundation.spacing.3-5` | dimension | — | ⚠️ TODO | 2 |
+| `foundation.spacing.4` | dimension | — | ⚠️ TODO | 29 |
+| `foundation.spacing.5` | dimension | — | ⚠️ TODO | 15 |
+| `foundation.spacing.6` | dimension | — | ⚠️ TODO | 17 |
+| `foundation.spacing.7` | dimension | — | ⚠️ TODO | 3 |
+| `foundation.spacing.8` | dimension | — | ⚠️ TODO | 10 |
+| `foundation.spacing.9` | dimension | — | ⚠️ TODO | 2 |
 
 ### foundation.typography
 
@@ -266,11 +266,11 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 | `foundation.typography.font.size.7xl` | dimension | — | ⚠️ TODO | 0 |
 | `foundation.typography.font.size.8xl` | dimension | — | ⚠️ TODO | 0 |
 | `foundation.typography.font.size.9xl` | dimension | — | ⚠️ TODO | 0 |
-| `foundation.typography.font.size.lg` | dimension | — | ⚠️ TODO | 2 |
+| `foundation.typography.font.size.lg` | dimension | — | ⚠️ TODO | 3 |
 | `foundation.typography.font.size.md` | dimension | — | ⚠️ TODO | 4 |
-| `foundation.typography.font.size.sm` | dimension | — | ⚠️ TODO | 6 |
+| `foundation.typography.font.size.sm` | dimension | — | ⚠️ TODO | 10 |
 | `foundation.typography.font.size.xl` | dimension | — | ⚠️ TODO | 2 |
-| `foundation.typography.font.size.xs` | dimension | — | ⚠️ TODO | 2 |
+| `foundation.typography.font.size.xs` | dimension | — | ⚠️ TODO | 3 |
 | `foundation.typography.font.weight.bold` | number | — | ⚠️ TODO | 2 |
 | `foundation.typography.font.weight.medium` | number | — | ⚠️ TODO | 2 |
 | `foundation.typography.font.weight.regular` | number | — | ⚠️ TODO | 2 |
@@ -443,7 +443,7 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 | `semantic.size.control.icon.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 4 |
 | `semantic.size.control.lg` | dimension | → `foundation.spacing.12` | ⚠️ TODO | 4 |
 | `semantic.size.control.md` | dimension | → `foundation.spacing.10` | ⚠️ TODO | 4 |
-| `semantic.size.control.min-target` | dimension | → `foundation.spacing.11` | ⚠️ TODO | 2 |
+| `semantic.size.control.min-target` | dimension | → `foundation.spacing.11` | ⚠️ TODO | 5 |
 | `semantic.size.control.sm` | dimension | → `foundation.spacing.8` | ⚠️ TODO | 4 |
 
 ### semantic.space
@@ -536,15 +536,15 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `component.avatar.font-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.font-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.font-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.icon-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.icon-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.icon-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.avatar.size.sm` | dimension | — | ⚠️ TODO | 1 |
+| `component.avatar.font-size.lg` | dimension | → `foundation.typography.font.size.lg` | ⚠️ TODO | 1 |
+| `component.avatar.font-size.md` | dimension | → `foundation.typography.font.size.sm` | ⚠️ TODO | 1 |
+| `component.avatar.font-size.sm` | dimension | → `foundation.typography.font.size.xs` | ⚠️ TODO | 1 |
+| `component.avatar.icon-size.lg` | dimension | → `foundation.spacing.7` | ⚠️ TODO | 1 |
+| `component.avatar.icon-size.md` | dimension | → `foundation.spacing.5` | ⚠️ TODO | 1 |
+| `component.avatar.icon-size.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
+| `component.avatar.size.lg` | dimension | → `foundation.spacing.14` | ⚠️ TODO | 1 |
+| `component.avatar.size.md` | dimension | → `foundation.spacing.10` | ⚠️ TODO | 1 |
+| `component.avatar.size.sm` | dimension | → `foundation.spacing.8` | ⚠️ TODO | 1 |
 
 ### component.button
 
@@ -582,18 +582,18 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 |---|---|---|---|---|
 | `component.checkbox.border-radius` | dimension | → `foundation.radius.sm` | ⚠️ TODO | 1 |
 | `component.checkbox.border-width` | dimension | → `semantic.border.width.default` | ⚠️ TODO | 1 |
-| `component.checkbox.check-height.lg` | dimension | — | ⚠️ TODO | 0 |
-| `component.checkbox.check-height.md` | dimension | — | ⚠️ TODO | 0 |
-| `component.checkbox.check-height.sm` | dimension | — | ⚠️ TODO | 0 |
-| `component.checkbox.check-width.lg` | dimension | — | ⚠️ TODO | 0 |
+| `component.checkbox.check-height.lg` | dimension | → `foundation.spacing.3` | ⚠️ TODO | 0 |
+| `component.checkbox.check-height.md` | dimension | → `foundation.spacing.2-5` | ⚠️ TODO | 0 |
+| `component.checkbox.check-height.sm` | dimension | → `foundation.spacing.2` | ⚠️ TODO | 0 |
+| `component.checkbox.check-width.lg` | dimension | → `foundation.spacing.1-5` | ⚠️ TODO | 0 |
 | `component.checkbox.check-width.md` | dimension | — | ⚠️ TODO | 0 |
-| `component.checkbox.check-width.sm` | dimension | — | ⚠️ TODO | 0 |
-| `component.checkbox.control-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.checkbox.control-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.checkbox.control-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.checkbox.font-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.checkbox.check-width.sm` | dimension | → `foundation.spacing.1` | ⚠️ TODO | 0 |
+| `component.checkbox.control-size.lg` | dimension | → `foundation.spacing.6` | ⚠️ TODO | 1 |
+| `component.checkbox.control-size.md` | dimension | → `foundation.spacing.5` | ⚠️ TODO | 1 |
+| `component.checkbox.control-size.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
+| `component.checkbox.font-size` | dimension | → `foundation.typography.font.size.sm` | ⚠️ TODO | 1 |
 | `component.checkbox.gap` | dimension | → `semantic.space.gap.sm` | ⚠️ TODO | 1 |
-| `component.checkbox.min-target-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.checkbox.min-target-size` | dimension | → `semantic.size.control.min-target` | ⚠️ TODO | 1 |
 
 ### component.input
 
@@ -634,24 +634,24 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
 | `component.radio.border-width` | dimension | → `semantic.border.width.default` | ⚠️ TODO | 1 |
-| `component.radio.control-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.control-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.control-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.dot-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.dot-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.dot-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.radio.font-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.radio.control-size.lg` | dimension | → `foundation.spacing.6` | ⚠️ TODO | 1 |
+| `component.radio.control-size.md` | dimension | → `foundation.spacing.5` | ⚠️ TODO | 1 |
+| `component.radio.control-size.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
+| `component.radio.dot-size.lg` | dimension | → `foundation.spacing.2-5` | ⚠️ TODO | 1 |
+| `component.radio.dot-size.md` | dimension | → `foundation.spacing.2` | ⚠️ TODO | 1 |
+| `component.radio.dot-size.sm` | dimension | → `foundation.spacing.1-5` | ⚠️ TODO | 1 |
+| `component.radio.font-size` | dimension | → `foundation.typography.font.size.sm` | ⚠️ TODO | 1 |
 | `component.radio.gap` | dimension | → `semantic.space.gap.sm` | ⚠️ TODO | 1 |
-| `component.radio.min-target-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.radio.min-target-size` | dimension | → `semantic.size.control.min-target` | ⚠️ TODO | 1 |
 
 ### component.select
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `component.select.arrow-offset.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.select.arrow-offset.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.select.arrow-offset.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.select.arrow-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.select.arrow-offset.lg` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
+| `component.select.arrow-offset.md` | dimension | → `foundation.spacing.3` | ⚠️ TODO | 1 |
+| `component.select.arrow-offset.sm` | dimension | → `foundation.spacing.2` | ⚠️ TODO | 1 |
+| `component.select.arrow-size` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
 | `component.select.border-radius` | dimension | → `semantic.radius.component` | ⚠️ TODO | 1 |
 | `component.select.border-width` | dimension | → `semantic.border.width.default` | ⚠️ TODO | 1 |
 | `component.select.font-size.lg` | dimension | → `semantic.typography.control.font-size.lg` | ⚠️ TODO | 1 |
@@ -672,20 +672,20 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `component.skeleton.circle-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.skeleton.circle-size` | dimension | → `foundation.spacing.10` | ⚠️ TODO | 1 |
 | `component.skeleton.fill` | color | → `semantic.state.disabled.background` | ⚠️ TODO | 1 |
 | `component.skeleton.rect-height` | dimension | — | ⚠️ TODO | 1 |
-| `component.skeleton.text-height` | dimension | — | ⚠️ TODO | 1 |
+| `component.skeleton.text-height` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
 
 ### component.spinner
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `component.spinner.size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.spinner.size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.spinner.size.sm` | dimension | — | ⚠️ TODO | 1 |
+| `component.spinner.size.lg` | dimension | → `foundation.spacing.8` | ⚠️ TODO | 1 |
+| `component.spinner.size.md` | dimension | → `foundation.spacing.6` | ⚠️ TODO | 1 |
+| `component.spinner.size.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
 | `component.spinner.stroke-width.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.spinner.stroke-width.md` | dimension | — | ⚠️ TODO | 1 |
+| `component.spinner.stroke-width.md` | dimension | → `foundation.spacing.0-5` | ⚠️ TODO | 1 |
 | `component.spinner.stroke-width.sm` | dimension | — | ⚠️ TODO | 1 |
 
 ### component.textarea
@@ -698,7 +698,7 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 | `component.textarea.font-size.md` | dimension | → `semantic.typography.control.font-size.md` | ⚠️ TODO | 1 |
 | `component.textarea.font-size.sm` | dimension | → `semantic.typography.control.font-size.sm` | ⚠️ TODO | 1 |
 | `component.textarea.min-height.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.textarea.min-height.md` | dimension | — | ⚠️ TODO | 1 |
+| `component.textarea.min-height.md` | dimension | → `foundation.spacing.20` | ⚠️ TODO | 1 |
 | `component.textarea.min-height.sm` | dimension | — | ⚠️ TODO | 1 |
 | `component.textarea.padding-x.lg` | dimension | → `semantic.space.control.padding-x.lg` | ⚠️ TODO | 1 |
 | `component.textarea.padding-x.md` | dimension | → `semantic.space.control.padding-x.md` | ⚠️ TODO | 1 |
@@ -711,18 +711,18 @@ Ver [ADR-013](decisions/ADR-013-camadas-de-consumo-de-tokens.md) para a regra ar
 
 | Token | Tipo | Alias | Sentido | Usos |
 |---|---|---|---|---|
-| `component.toggle.font-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.toggle.font-size` | dimension | → `foundation.typography.font.size.sm` | ⚠️ TODO | 1 |
 | `component.toggle.gap` | dimension | → `semantic.space.gap.sm` | ⚠️ TODO | 1 |
-| `component.toggle.min-target-size` | dimension | — | ⚠️ TODO | 1 |
+| `component.toggle.min-target-size` | dimension | → `semantic.size.control.min-target` | ⚠️ TODO | 1 |
 | `component.toggle.thumb-size.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.thumb-size.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.thumb-size.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-height.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-height.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-height.sm` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-width.lg` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-width.md` | dimension | — | ⚠️ TODO | 1 |
-| `component.toggle.track-width.sm` | dimension | — | ⚠️ TODO | 1 |
+| `component.toggle.thumb-size.md` | dimension | → `foundation.spacing.3-5` | ⚠️ TODO | 1 |
+| `component.toggle.thumb-size.sm` | dimension | → `foundation.spacing.2-5` | ⚠️ TODO | 1 |
+| `component.toggle.track-height.lg` | dimension | → `foundation.spacing.6` | ⚠️ TODO | 1 |
+| `component.toggle.track-height.md` | dimension | → `foundation.spacing.5` | ⚠️ TODO | 1 |
+| `component.toggle.track-height.sm` | dimension | → `foundation.spacing.4` | ⚠️ TODO | 1 |
+| `component.toggle.track-width.lg` | dimension | → `foundation.spacing.11` | ⚠️ TODO | 1 |
+| `component.toggle.track-width.md` | dimension | → `foundation.spacing.9` | ⚠️ TODO | 1 |
+| `component.toggle.track-width.sm` | dimension | → `foundation.spacing.7` | ⚠️ TODO | 1 |
 
 ---
 
@@ -2851,6 +2851,7 @@ Seção expandida com contexto, decisão e locais de uso.
   - CSS:
     - `css/base/reset.css` (1×)
     - `css/components/badge.css` (1×)
+    - `css/tokens/generated/component.css` (1×)
     - `css/tokens/generated/theme-dark.css` (2×)
     - `css/tokens/generated/theme-light.css` (2×)
 
@@ -2866,9 +2867,10 @@ Seção expandida com contexto, decisão e locais de uso.
   - CSS:
     - `css/base/reset.css` (1×)
     - `css/components/badge.css` (1×)
+    - `css/tokens/generated/component.css` (1×)
     - `css/tokens/generated/theme-dark.css` (2×)
     - `css/tokens/generated/theme-light.css` (2×)
-  - Tokens que referenciam: `semantic.space.inset.2xs`, `semantic.space.gap.2xs`, `semantic.space.inset.2xs`, `semantic.space.gap.2xs`
+  - Tokens que referenciam: `component.spinner.stroke-width.md`, `semantic.space.inset.2xs`, `semantic.space.gap.2xs`, `semantic.space.inset.2xs`, `semantic.space.gap.2xs`
 
 ### `foundation.spacing.1`
 
@@ -2890,9 +2892,10 @@ Seção expandida com contexto, decisão e locais de uso.
     - `css/components/textarea.css` (3×)
     - `css/components/toggle.css` (3×)
     - `css/components/tooltip.css` (1×)
+    - `css/tokens/generated/component.css` (3×)
     - `css/tokens/generated/theme-dark.css` (3×)
     - `css/tokens/generated/theme-light.css` (3×)
-  - Tokens que referenciam: `semantic.space.inset.xs`, `semantic.space.gap.xs`, `semantic.space.component.xs`, `semantic.space.inset.xs`, `semantic.space.gap.xs`, `semantic.space.component.xs`
+  - Tokens que referenciam: `component.checkbox.check-width.sm`, `semantic.space.inset.xs`, `semantic.space.gap.xs`, `semantic.space.component.xs`, `semantic.space.inset.xs`, `semantic.space.gap.xs`, `semantic.space.component.xs`
 
 ### `foundation.spacing.1-5`
 
@@ -2907,6 +2910,8 @@ Seção expandida com contexto, decisão e locais de uso.
     - `css/components/checkbox.css` (1×)
     - `css/components/radio.css` (1×)
     - `css/components/toggle.css` (1×)
+    - `css/tokens/generated/component.css` (2×)
+  - Tokens que referenciam: `component.checkbox.check-width.lg`, `component.radio.dot-size.sm`
 
 ### `foundation.spacing.10`
 
@@ -2918,9 +2923,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (2×)
     - `css/tokens/generated/theme-dark.css` (1×)
     - `css/tokens/generated/theme-light.css` (1×)
-  - Tokens que referenciam: `semantic.size.control.md`, `semantic.size.control.md`
+  - Tokens que referenciam: `component.avatar.size.md`, `component.skeleton.circle-size`, `semantic.size.control.md`, `semantic.size.control.md`
 
 ### `foundation.spacing.11`
 
@@ -2932,9 +2938,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (1×)
     - `css/tokens/generated/theme-dark.css` (1×)
     - `css/tokens/generated/theme-light.css` (1×)
-  - Tokens que referenciam: `semantic.size.control.min-target`, `semantic.size.control.min-target`
+  - Tokens que referenciam: `component.toggle.track-width.lg`, `semantic.size.control.min-target`, `semantic.size.control.min-target`
 
 ### `foundation.spacing.12`
 
@@ -2959,7 +2966,9 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - _(nenhum uso detectado — token órfão ou novo)_
+  - CSS:
+    - `css/tokens/generated/component.css` (1×)
+  - Tokens que referenciam: `component.avatar.size.lg`
 
 ### `foundation.spacing.16`
 
@@ -2992,9 +3001,10 @@ Seção expandida com contexto, decisão e locais de uso.
     - `css/components/radio.css` (1×)
     - `css/components/tabs.css` (1×)
     - `css/components/tooltip.css` (1×)
+    - `css/tokens/generated/component.css` (6×)
     - `css/tokens/generated/theme-dark.css` (5×)
     - `css/tokens/generated/theme-light.css` (5×)
-  - Tokens que referenciam: `semantic.space.inset.sm`, `semantic.space.gap.sm`, `semantic.space.component.sm`, `semantic.space.control.padding-y.sm`, `semantic.space.inset.sm`, `semantic.space.gap.sm`, `semantic.space.component.sm`, `semantic.space.control.padding-y.sm`
+  - Tokens que referenciam: `component.checkbox.check-height.sm`, `component.radio.dot-size.md`, `component.select.arrow-offset.sm`, `semantic.space.inset.sm`, `semantic.space.gap.sm`, `semantic.space.component.sm`, `semantic.space.control.padding-y.sm`, `semantic.space.inset.sm`, `semantic.space.gap.sm`, `semantic.space.component.sm`, `semantic.space.control.padding-y.sm`
 
 ### `foundation.spacing.2-5`
 
@@ -3006,9 +3016,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (3×)
     - `css/tokens/generated/theme-dark.css` (1×)
     - `css/tokens/generated/theme-light.css` (1×)
-  - Tokens que referenciam: `semantic.space.control.padding-y.md`, `semantic.space.control.padding-y.md`
+  - Tokens que referenciam: `component.checkbox.check-height.md`, `component.radio.dot-size.lg`, `component.toggle.thumb-size.sm`, `semantic.space.control.padding-y.md`, `semantic.space.control.padding-y.md`
 
 ### `foundation.spacing.20`
 
@@ -3020,9 +3031,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (1×)
     - `css/tokens/generated/theme-dark.css` (1×)
     - `css/tokens/generated/theme-light.css` (1×)
-  - Tokens que referenciam: `semantic.space.section.xl`, `semantic.space.section.xl`
+  - Tokens que referenciam: `component.textarea.min-height.md`, `semantic.space.section.xl`, `semantic.space.section.xl`
 
 ### `foundation.spacing.24`
 
@@ -3047,9 +3059,10 @@ Seção expandida com contexto, decisão e locais de uso.
   - CSS:
     - `css/base/reset.css` (1×)
     - `css/components/alert.css` (1×)
+    - `css/tokens/generated/component.css` (3×)
     - `css/tokens/generated/theme-dark.css` (5×)
     - `css/tokens/generated/theme-light.css` (5×)
-  - Tokens que referenciam: `semantic.space.inset.md`, `semantic.space.gap.md`, `semantic.space.component.md`, `semantic.space.control.padding-x.sm`, `semantic.space.control.padding-y.lg`, `semantic.space.inset.md`, `semantic.space.gap.md`, `semantic.space.component.md`, `semantic.space.control.padding-x.sm`, `semantic.space.control.padding-y.lg`
+  - Tokens que referenciam: `component.checkbox.check-height.lg`, `component.select.arrow-offset.md`, `semantic.space.inset.md`, `semantic.space.gap.md`, `semantic.space.component.md`, `semantic.space.control.padding-x.sm`, `semantic.space.control.padding-y.lg`, `semantic.space.inset.md`, `semantic.space.gap.md`, `semantic.space.component.md`, `semantic.space.control.padding-x.sm`, `semantic.space.control.padding-y.lg`
 
 ### `foundation.spacing.3-5`
 
@@ -3060,7 +3073,9 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - _(nenhum uso detectado — token órfão ou novo)_
+  - CSS:
+    - `css/tokens/generated/component.css` (1×)
+  - Tokens que referenciam: `component.toggle.thumb-size.md`
 
 ### `foundation.spacing.4`
 
@@ -3078,9 +3093,10 @@ Seção expandida com contexto, decisão e locais de uso.
     - `css/components/modal.css` (7×)
     - `css/components/radio.css` (1×)
     - `css/components/tabs.css` (2×)
+    - `css/tokens/generated/component.css` (8×)
     - `css/tokens/generated/theme-dark.css` (6×)
     - `css/tokens/generated/theme-light.css` (6×)
-  - Tokens que referenciam: `semantic.space.inset.lg`, `semantic.space.gap.lg`, `semantic.space.component.lg`, `semantic.space.control.padding-x.md`, `semantic.size.control.icon.sm`, `semantic.typography.control.line-height.sm`, `semantic.space.inset.lg`, `semantic.space.gap.lg`, `semantic.space.component.lg`, `semantic.space.control.padding-x.md`, `semantic.size.control.icon.sm`, `semantic.typography.control.line-height.sm`
+  - Tokens que referenciam: `component.avatar.icon-size.sm`, `component.checkbox.control-size.sm`, `component.radio.control-size.sm`, `component.select.arrow-size`, `component.select.arrow-offset.lg`, `component.skeleton.text-height`, `component.spinner.size.sm`, `component.toggle.track-height.sm`, `semantic.space.inset.lg`, `semantic.space.gap.lg`, `semantic.space.component.lg`, `semantic.space.control.padding-x.md`, `semantic.size.control.icon.sm`, `semantic.typography.control.line-height.sm`, `semantic.space.inset.lg`, `semantic.space.gap.lg`, `semantic.space.component.lg`, `semantic.space.control.padding-x.md`, `semantic.size.control.icon.sm`, `semantic.typography.control.line-height.sm`
 
 ### `foundation.spacing.5`
 
@@ -3092,9 +3108,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (4×)
     - `css/tokens/generated/theme-dark.css` (4×)
     - `css/tokens/generated/theme-light.css` (4×)
-  - Tokens que referenciam: `semantic.space.component.xl`, `semantic.space.control.padding-x.lg`, `semantic.size.control.icon.md`, `semantic.typography.control.line-height.md`, `semantic.space.component.xl`, `semantic.space.control.padding-x.lg`, `semantic.size.control.icon.md`, `semantic.typography.control.line-height.md`
+  - Tokens que referenciam: `component.avatar.icon-size.md`, `component.checkbox.control-size.md`, `component.radio.control-size.md`, `component.toggle.track-height.md`, `semantic.space.component.xl`, `semantic.space.control.padding-x.lg`, `semantic.size.control.icon.md`, `semantic.typography.control.line-height.md`, `semantic.space.component.xl`, `semantic.space.control.padding-x.lg`, `semantic.size.control.icon.md`, `semantic.typography.control.line-height.md`
 
 ### `foundation.spacing.6`
 
@@ -3106,9 +3123,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
+    - `css/tokens/generated/component.css` (4×)
     - `css/tokens/generated/theme-dark.css` (5×)
     - `css/tokens/generated/theme-light.css` (5×)
-  - Tokens que referenciam: `semantic.space.inset.xl`, `semantic.space.gap.xl`, `semantic.space.component.2xl`, `semantic.size.control.icon.lg`, `semantic.typography.control.line-height.lg`, `semantic.space.inset.xl`, `semantic.space.gap.xl`, `semantic.space.component.2xl`, `semantic.size.control.icon.lg`, `semantic.typography.control.line-height.lg`
+  - Tokens que referenciam: `component.checkbox.control-size.lg`, `component.radio.control-size.lg`, `component.spinner.size.md`, `component.toggle.track-height.lg`, `semantic.space.inset.xl`, `semantic.space.gap.xl`, `semantic.space.component.2xl`, `semantic.size.control.icon.lg`, `semantic.typography.control.line-height.lg`, `semantic.space.inset.xl`, `semantic.space.gap.xl`, `semantic.space.component.2xl`, `semantic.size.control.icon.lg`, `semantic.typography.control.line-height.lg`
 
 ### `foundation.spacing.7`
 
@@ -3119,7 +3137,9 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - _(nenhum uso detectado — token órfão ou novo)_
+  - CSS:
+    - `css/tokens/generated/component.css` (2×)
+  - Tokens que referenciam: `component.avatar.icon-size.lg`, `component.toggle.track-width.sm`
 
 ### `foundation.spacing.8`
 
@@ -3132,9 +3152,10 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Usos**:
   - CSS:
     - `css/components/modal.css` (1×)
+    - `css/tokens/generated/component.css` (2×)
     - `css/tokens/generated/theme-dark.css` (2×)
     - `css/tokens/generated/theme-light.css` (2×)
-  - Tokens que referenciam: `semantic.space.section.sm`, `semantic.size.control.sm`, `semantic.space.section.sm`, `semantic.size.control.sm`
+  - Tokens que referenciam: `component.avatar.size.sm`, `component.spinner.size.lg`, `semantic.space.section.sm`, `semantic.size.control.sm`, `semantic.space.section.sm`, `semantic.size.control.sm`
 
 ### `foundation.spacing.9`
 
@@ -3145,7 +3166,9 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - _(nenhum uso detectado — token órfão ou novo)_
+  - CSS:
+    - `css/tokens/generated/component.css` (1×)
+  - Tokens que referenciam: `component.toggle.track-width.md`
 
 ### `foundation.typography.font.family.display`
 
@@ -3288,7 +3311,7 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - Tokens que referenciam: `semantic.typography.body.font-size.lg`, `semantic.typography.body.font-size.lg`
+  - Tokens que referenciam: `component.avatar.font-size.lg`, `semantic.typography.body.font-size.lg`, `semantic.typography.body.font-size.lg`
 
 ### `foundation.typography.font.size.md`
 
@@ -3310,7 +3333,7 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - Tokens que referenciam: `semantic.typography.control.font-size.sm`, `semantic.typography.control.font-size.md`, `semantic.typography.body.font-size.sm`, `semantic.typography.control.font-size.sm`, `semantic.typography.control.font-size.md`, `semantic.typography.body.font-size.sm`
+  - Tokens que referenciam: `component.avatar.font-size.md`, `component.checkbox.font-size`, `component.radio.font-size`, `component.toggle.font-size`, `semantic.typography.control.font-size.sm`, `semantic.typography.control.font-size.md`, `semantic.typography.body.font-size.sm`, `semantic.typography.control.font-size.sm`, `semantic.typography.control.font-size.md`, `semantic.typography.body.font-size.sm`
 
 ### `foundation.typography.font.size.xl`
 
@@ -3332,7 +3355,7 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Contexto**: TODO
 - **Decisão**: TODO
 - **Usos**:
-  - Tokens que referenciam: `semantic.typography.body.font-size.xs`, `semantic.typography.body.font-size.xs`
+  - Tokens que referenciam: `component.avatar.font-size.sm`, `semantic.typography.body.font-size.xs`, `semantic.typography.body.font-size.xs`
 
 ### `foundation.typography.font.weight.bold`
 
@@ -4899,8 +4922,8 @@ Seção expandida com contexto, decisão e locais de uso.
 - **Decisão**: TODO
 - **Usos**:
   - CSS:
-    - `css/tokens/generated/component.css` (1×)
-  - Tokens que referenciam: `component.button.min-target-size`
+    - `css/tokens/generated/component.css` (4×)
+  - Tokens que referenciam: `component.button.min-target-size`, `component.checkbox.min-target-size`, `component.radio.min-target-size`, `component.toggle.min-target-size`
 
 ### `semantic.size.control.sm`
 
@@ -5711,6 +5734,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.lg`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5723,6 +5747,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.sm`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5735,6 +5760,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.xs`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5747,6 +5773,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.7`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5759,6 +5786,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5771,6 +5799,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5783,6 +5812,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.14`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5795,6 +5825,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.10`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -5807,6 +5838,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.8`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6164,6 +6196,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.3`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6175,6 +6208,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6186,6 +6220,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6197,6 +6232,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.1-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6219,6 +6255,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.1`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6230,6 +6267,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.6`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6242,6 +6280,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6254,6 +6293,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6266,6 +6306,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.sm`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6291,6 +6332,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `semantic.size.control.min-target`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6621,6 +6663,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.6`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6633,6 +6676,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6645,6 +6689,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6657,6 +6702,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6669,6 +6715,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6681,6 +6728,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.1-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6693,6 +6741,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.sm`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6718,6 +6767,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `semantic.size.control.min-target`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6730,6 +6780,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6742,6 +6793,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.3`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6754,6 +6806,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6766,6 +6819,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -6970,6 +7024,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.10`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7007,6 +7062,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7019,6 +7075,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.8`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7031,6 +7088,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.6`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7043,6 +7101,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7067,6 +7126,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.0-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7168,6 +7228,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.20`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7270,6 +7331,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.typography.font.size.sm`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7295,6 +7357,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `semantic.size.control.min-target`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7319,6 +7382,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.3-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7331,6 +7395,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.2-5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7343,6 +7408,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.6`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7355,6 +7421,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.5`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7367,6 +7434,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.4`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7379,6 +7447,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.11`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7391,6 +7460,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.9`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO
@@ -7403,6 +7473,7 @@ Seção expandida com contexto, decisão e locais de uso.
 
 - **Camada**: component
 - **Tipo**: `dimension`
+- **Alias**: → `foundation.spacing.7`
 - **Sentido**: TODO
 - **Escopo**: —
 - **Contexto**: TODO

--- a/docs/tokens-sync.html
+++ b/docs/tokens-sync.html
@@ -61,11 +61,11 @@
   </div>
 
   <div class="ds-section">
-    <span class="ds-sync-status error">2 divergência(s)</span>
+    <span class="ds-sync-status ok">Em dia</span>
     <div class="ds-sync-meta">
-      <div><strong>Última verificação:</strong> 2026-04-22T18:19:23.613Z</div>
+      <div><strong>Última verificação:</strong> 2026-04-22T19:55:11.876Z</div>
       <div><strong>Tokens JSON:</strong> 674</div>
-      <div><strong>Divergências:</strong> 2</div>
+      <div><strong>Divergências:</strong> 0</div>
       <div><strong>Avisos:</strong> 0</div>
     </div>
   </div>
@@ -76,21 +76,7 @@
       <thead>
         <tr><th>Checagem</th><th>Token</th><th>Mensagem</th><th>JSON</th><th>CSS</th></tr>
       </thead>
-      <tbody>
-    <tr>
-      <td><code>JSON ↔ Figma</code></td>
-      <td><code>component.checkbox.border-radius</code></td>
-      <td>valor difere: Figma=4 / JSON="{foundation.radius.sm}"</td>
-      <td><code>{foundation.radius.sm}</code></td>
-      <td><code>—</code></td>
-    </tr>
-    <tr>
-      <td><code>JSON ↔ Figma</code></td>
-      <td><code>component.modal.border-radius</code></td>
-      <td>valor difere: Figma=16 / JSON="{foundation.radius.xl}"</td>
-      <td><code>{foundation.radius.xl}</code></td>
-      <td><code>—</code></td>
-    </tr></tbody>
+      <tbody><tr><td colspan="5" style="text-align:center;color:var(--ds-content-secondary)">Nenhuma divergência registrada.</td></tr></tbody>
     </table>
   </div>
 </main>

--- a/tokens/component/avatar.json
+++ b/tokens/component/avatar.json
@@ -3,19 +3,55 @@
     "avatar": {
       "$description": "Structural tokens for Avatar component.",
       "size": {
-        "sm": { "$type": "dimension", "$value": "2rem", "$description": "32px" },
-        "md": { "$type": "dimension", "$value": "2.5rem", "$description": "40px" },
-        "lg": { "$type": "dimension", "$value": "3.5rem", "$description": "56px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.8}",
+          "$description": "32px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.10}",
+          "$description": "40px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.14}",
+          "$description": "56px"
+        }
       },
       "font-size": {
-        "sm": { "$type": "dimension", "$value": "0.75rem", "$description": "12px initials" },
-        "md": { "$type": "dimension", "$value": "0.875rem", "$description": "14px initials" },
-        "lg": { "$type": "dimension", "$value": "1.125rem", "$description": "18px initials" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.typography.font.size.xs}",
+          "$description": "12px initials"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.typography.font.size.sm}",
+          "$description": "14px initials"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.typography.font.size.lg}",
+          "$description": "18px initials"
+        }
       },
       "icon-size": {
-        "sm": { "$type": "dimension", "$value": "1rem", "$description": "16px" },
-        "md": { "$type": "dimension", "$value": "1.25rem", "$description": "20px" },
-        "lg": { "$type": "dimension", "$value": "1.75rem", "$description": "28px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.4}",
+          "$description": "16px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.5}",
+          "$description": "20px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.7}",
+          "$description": "28px"
+        }
       }
     }
   }

--- a/tokens/component/checkbox.json
+++ b/tokens/component/checkbox.json
@@ -5,24 +5,24 @@
       "control-size": {
         "sm": {
           "$type": "dimension",
-          "$value": "1rem",
+          "$value": "{foundation.spacing.4}",
           "$description": "16px"
         },
         "md": {
           "$type": "dimension",
-          "$value": "1.25rem",
+          "$value": "{foundation.spacing.5}",
           "$description": "20px"
         },
         "lg": {
           "$type": "dimension",
-          "$value": "1.5rem",
+          "$value": "{foundation.spacing.6}",
           "$description": "24px"
         }
       },
       "check-width": {
         "sm": {
           "$type": "dimension",
-          "$value": "4px"
+          "$value": "{foundation.spacing.1}"
         },
         "md": {
           "$type": "dimension",
@@ -30,27 +30,27 @@
         },
         "lg": {
           "$type": "dimension",
-          "$value": "6px"
+          "$value": "{foundation.spacing.1-5}"
         }
       },
       "check-height": {
         "sm": {
           "$type": "dimension",
-          "$value": "8px"
+          "$value": "{foundation.spacing.2}"
         },
         "md": {
           "$type": "dimension",
-          "$value": "10px"
+          "$value": "{foundation.spacing.2-5}"
         },
         "lg": {
           "$type": "dimension",
-          "$value": "12px"
+          "$value": "{foundation.spacing.3}"
         }
       },
       "border-radius": {
         "$type": "dimension",
         "$value": "{foundation.radius.sm}",
-        "$description": "4px \u2014 smaller radius for compact control"
+        "$description": "4px — smaller radius for compact control"
       },
       "border-width": {
         "$type": "dimension",
@@ -63,12 +63,12 @@
       },
       "min-target-size": {
         "$type": "dimension",
-        "$value": "2.75rem",
-        "$description": "44px \u2014 WCAG 2.5.5"
+        "$value": "{semantic.size.control.min-target}",
+        "$description": "44px — WCAG 2.5.5"
       },
       "font-size": {
         "$type": "dimension",
-        "$value": "0.875rem",
+        "$value": "{foundation.typography.font.size.sm}",
         "$description": "14px label"
       }
     }

--- a/tokens/component/radio.json
+++ b/tokens/component/radio.json
@@ -3,19 +3,55 @@
     "radio": {
       "$description": "Structural tokens for Radio component.",
       "control-size": {
-        "sm": { "$type": "dimension", "$value": "1rem", "$description": "16px" },
-        "md": { "$type": "dimension", "$value": "1.25rem", "$description": "20px" },
-        "lg": { "$type": "dimension", "$value": "1.5rem", "$description": "24px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.4}",
+          "$description": "16px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.5}",
+          "$description": "20px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.6}",
+          "$description": "24px"
+        }
       },
       "dot-size": {
-        "sm": { "$type": "dimension", "$value": "6px" },
-        "md": { "$type": "dimension", "$value": "8px" },
-        "lg": { "$type": "dimension", "$value": "10px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.1-5}"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.2}"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.2-5}"
+        }
       },
-      "border-width": { "$type": "dimension", "$value": "{semantic.border.width.default}" },
-      "gap": { "$type": "dimension", "$value": "{semantic.space.gap.sm}", "$description": "8px between control and label" },
-      "min-target-size": { "$type": "dimension", "$value": "2.75rem", "$description": "44px — WCAG 2.5.5" },
-      "font-size": { "$type": "dimension", "$value": "0.875rem", "$description": "14px label" }
+      "border-width": {
+        "$type": "dimension",
+        "$value": "{semantic.border.width.default}"
+      },
+      "gap": {
+        "$type": "dimension",
+        "$value": "{semantic.space.gap.sm}",
+        "$description": "8px between control and label"
+      },
+      "min-target-size": {
+        "$type": "dimension",
+        "$value": "{semantic.size.control.min-target}",
+        "$description": "44px — WCAG 2.5.5"
+      },
+      "font-size": {
+        "$type": "dimension",
+        "$value": "{foundation.typography.font.size.sm}",
+        "$description": "14px label"
+      }
     }
   }
 }

--- a/tokens/component/select.json
+++ b/tokens/component/select.json
@@ -3,33 +3,107 @@
     "select": {
       "$description": "Structural tokens for Select component. References semantic control tokens (ADR-006).",
       "height": {
-        "sm": { "$type": "dimension", "$value": "{semantic.size.control.sm}", "$description": "32px" },
-        "md": { "$type": "dimension", "$value": "{semantic.size.control.md}", "$description": "40px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.size.control.lg}", "$description": "48px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.size.control.sm}",
+          "$description": "32px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.size.control.md}",
+          "$description": "40px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.size.control.lg}",
+          "$description": "48px"
+        }
       },
       "padding-x": {
-        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.sm}", "$description": "12px" },
-        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.md}", "$description": "16px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.lg}", "$description": "20px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.sm}",
+          "$description": "12px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.md}",
+          "$description": "16px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.lg}",
+          "$description": "20px"
+        }
       },
       "padding-y": {
-        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.sm}", "$description": "8px" },
-        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.md}", "$description": "10px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.lg}", "$description": "12px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.sm}",
+          "$description": "8px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.md}",
+          "$description": "10px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.lg}",
+          "$description": "12px"
+        }
       },
-      "gap": { "$type": "dimension", "$value": "{semantic.space.gap.xs}", "$description": "4px" },
-      "border-radius": { "$type": "dimension", "$value": "{semantic.radius.component}" },
-      "border-width": { "$type": "dimension", "$value": "{semantic.border.width.default}" },
+      "gap": {
+        "$type": "dimension",
+        "$value": "{semantic.space.gap.xs}",
+        "$description": "4px"
+      },
+      "border-radius": {
+        "$type": "dimension",
+        "$value": "{semantic.radius.component}"
+      },
+      "border-width": {
+        "$type": "dimension",
+        "$value": "{semantic.border.width.default}"
+      },
       "font-size": {
-        "sm": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.sm}", "$description": "14px" },
-        "md": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.md}", "$description": "14px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.lg}", "$description": "16px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.sm}",
+          "$description": "14px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.md}",
+          "$description": "14px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.lg}",
+          "$description": "16px"
+        }
       },
-      "arrow-size": { "$type": "dimension", "$value": "1rem", "$description": "16px" },
+      "arrow-size": {
+        "$type": "dimension",
+        "$value": "{foundation.spacing.4}",
+        "$description": "16px"
+      },
       "arrow-offset": {
-        "sm": { "$type": "dimension", "$value": "0.5rem", "$description": "8px from right edge" },
-        "md": { "$type": "dimension", "$value": "0.75rem", "$description": "12px" },
-        "lg": { "$type": "dimension", "$value": "1rem", "$description": "16px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.2}",
+          "$description": "8px from right edge"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.3}",
+          "$description": "12px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.4}",
+          "$description": "16px"
+        }
       }
     }
   }

--- a/tokens/component/skeleton.json
+++ b/tokens/component/skeleton.json
@@ -2,9 +2,21 @@
   "component": {
     "skeleton": {
       "$description": "Structural tokens for Skeleton placeholder component.",
-      "text-height": { "$type": "dimension", "$value": "1rem", "$description": "16px line placeholder" },
-      "circle-size": { "$type": "dimension", "$value": "2.5rem", "$description": "40px avatar placeholder" },
-      "rect-height": { "$type": "dimension", "$value": "7.5rem", "$description": "120px image/card placeholder" },
+      "text-height": {
+        "$type": "dimension",
+        "$value": "{foundation.spacing.4}",
+        "$description": "16px line placeholder"
+      },
+      "circle-size": {
+        "$type": "dimension",
+        "$value": "{foundation.spacing.10}",
+        "$description": "40px avatar placeholder"
+      },
+      "rect-height": {
+        "$type": "dimension",
+        "$value": "7.5rem",
+        "$description": "120px image/card placeholder"
+      },
       "fill": {
         "$type": "color",
         "$value": "{semantic.state.disabled.background}",

--- a/tokens/component/spinner.json
+++ b/tokens/component/spinner.json
@@ -3,14 +3,35 @@
     "spinner": {
       "$description": "Structural tokens for Spinner/Loading component.",
       "size": {
-        "sm": { "$type": "dimension", "$value": "1rem", "$description": "16px" },
-        "md": { "$type": "dimension", "$value": "1.5rem", "$description": "24px" },
-        "lg": { "$type": "dimension", "$value": "2rem", "$description": "32px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.4}",
+          "$description": "16px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.6}",
+          "$description": "24px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.8}",
+          "$description": "32px"
+        }
       },
       "stroke-width": {
-        "sm": { "$type": "dimension", "$value": "1.5px" },
-        "md": { "$type": "dimension", "$value": "2px" },
-        "lg": { "$type": "dimension", "$value": "3px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "1.5px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.0-5}"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "3px"
+        }
       }
     }
   }

--- a/tokens/component/textarea.json
+++ b/tokens/component/textarea.json
@@ -3,26 +3,80 @@
     "textarea": {
       "$description": "Structural tokens for Textarea component. Shares padding-x with controls (ADR-006). Height and line-height are independent (multi-line).",
       "min-height": {
-        "sm": { "$type": "dimension", "$value": "4.25rem", "$description": "68px" },
-        "md": { "$type": "dimension", "$value": "5rem", "$description": "80px" },
-        "lg": { "$type": "dimension", "$value": "7rem", "$description": "112px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "4.25rem",
+          "$description": "68px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.20}",
+          "$description": "80px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "7rem",
+          "$description": "112px"
+        }
       },
       "padding-x": {
-        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.sm}", "$description": "12px" },
-        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.md}", "$description": "16px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-x.lg}", "$description": "20px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.sm}",
+          "$description": "12px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.md}",
+          "$description": "16px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-x.lg}",
+          "$description": "20px"
+        }
       },
       "padding-y": {
-        "sm": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.sm}", "$description": "8px" },
-        "md": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.md}", "$description": "10px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.space.control.padding-y.lg}", "$description": "12px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.sm}",
+          "$description": "8px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.md}",
+          "$description": "10px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.space.control.padding-y.lg}",
+          "$description": "12px"
+        }
       },
-      "border-radius": { "$type": "dimension", "$value": "{semantic.radius.component}" },
-      "border-width": { "$type": "dimension", "$value": "{semantic.border.width.default}" },
+      "border-radius": {
+        "$type": "dimension",
+        "$value": "{semantic.radius.component}"
+      },
+      "border-width": {
+        "$type": "dimension",
+        "$value": "{semantic.border.width.default}"
+      },
       "font-size": {
-        "sm": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.sm}", "$description": "14px" },
-        "md": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.md}", "$description": "14px" },
-        "lg": { "$type": "dimension", "$value": "{semantic.typography.control.font-size.lg}", "$description": "16px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.sm}",
+          "$description": "14px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.md}",
+          "$description": "14px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{semantic.typography.control.font-size.lg}",
+          "$description": "16px"
+        }
       }
     }
   }

--- a/tokens/component/toggle.json
+++ b/tokens/component/toggle.json
@@ -3,23 +3,71 @@
     "toggle": {
       "$description": "Structural tokens for Toggle/Switch component.",
       "track-width": {
-        "sm": { "$type": "dimension", "$value": "1.75rem", "$description": "28px" },
-        "md": { "$type": "dimension", "$value": "2.25rem", "$description": "36px" },
-        "lg": { "$type": "dimension", "$value": "2.75rem", "$description": "44px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.7}",
+          "$description": "28px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.9}",
+          "$description": "36px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.11}",
+          "$description": "44px"
+        }
       },
       "track-height": {
-        "sm": { "$type": "dimension", "$value": "1rem", "$description": "16px" },
-        "md": { "$type": "dimension", "$value": "1.25rem", "$description": "20px" },
-        "lg": { "$type": "dimension", "$value": "1.5rem", "$description": "24px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.4}",
+          "$description": "16px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.5}",
+          "$description": "20px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.6}",
+          "$description": "24px"
+        }
       },
       "thumb-size": {
-        "sm": { "$type": "dimension", "$value": "0.625rem", "$description": "10px" },
-        "md": { "$type": "dimension", "$value": "0.875rem", "$description": "14px" },
-        "lg": { "$type": "dimension", "$value": "1.125rem", "$description": "18px" }
+        "sm": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.2-5}",
+          "$description": "10px"
+        },
+        "md": {
+          "$type": "dimension",
+          "$value": "{foundation.spacing.3-5}",
+          "$description": "14px"
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "1.125rem",
+          "$description": "18px"
+        }
       },
-      "gap": { "$type": "dimension", "$value": "{semantic.space.gap.sm}", "$description": "8px between toggle and label" },
-      "min-target-size": { "$type": "dimension", "$value": "2.75rem", "$description": "44px — WCAG 2.5.5" },
-      "font-size": { "$type": "dimension", "$value": "0.875rem", "$description": "14px label" }
+      "gap": {
+        "$type": "dimension",
+        "$value": "{semantic.space.gap.sm}",
+        "$description": "8px between toggle and label"
+      },
+      "min-target-size": {
+        "$type": "dimension",
+        "$value": "{semantic.size.control.min-target}",
+        "$description": "44px — WCAG 2.5.5"
+      },
+      "font-size": {
+        "$type": "dimension",
+        "$value": "{foundation.typography.font.size.sm}",
+        "$description": "14px label"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Completa **Fases 2 e 3** do plano ADR-013 (camadas de consumo de tokens). Arquivo de plano: `/Users/marcelldasilva/.claude/plans/groovy-snacking-acorn.md`.

**Fase 2 — Rebind de 3.479 bindings Foundation em componentes Figma**

Todos os 51 componentes (+ 28 text styles locais) tiveram seus bindings rebindados de Foundation pra Semantic. Pós-audit: **0 Foundation bindings remanescentes** no arquivo Figma. Regra ADR-013 cumprida 100% no lado do design.

Passes executados:
- Icons (30 componentes, 60 rebinds)
- Global typography + borders em todos componentes (2.759)
- Font-size/line-height em não-controles → `semantic.typography.body.*` (268)
- Font-size/line-height em controles → `semantic.typography.control.*` / `body.*` contextual (210)
- Cleanup com IDs corrigidos (2.073)
- Text styles locais (98) — destravou nodes herdeiros

**Fase 3 — Converter 50 de 60 raw values em Component collection pra aliases**

Exemplos:
- `avatar/size/sm` (32) → `{foundation.spacing.8}`
- `checkbox/border-radius` (4) → `{foundation.radius.sm}` ✅ resolve o VALUE_DRIFT histórico
- `modal/border-radius` (16) → `{foundation.radius.xl}` ✅ idem
- `radio/min-target-size` (44) → `{semantic.size.control.min-target}` — reaproveita alias existente

10 vars permanecem raw como exceção ADR-013 (documentado no CHANGELOG):
- `modal/max-width/{sm,md,lg}` (400/520/640)
- `textarea/min-height/{sm,lg}` (68/112)
- `skeleton/rect-height` (120)
- `spinner/stroke-width/{sm,lg}` (1.5/3)
- `toggle/thumb-size/lg` (18)
- `checkbox/check-width/md` (5)

Todos são valores sem ponto correspondente na escala Foundation — aceitar raw é permitido pelo ADR-013 quando não há abstração possível.

## Impacto

- **`verify:tokens`**: de 2 VALUE_DRIFT pra **0 errors, 0 warnings**. Figma ↔ JSON ↔ CSS totalmente sincronizados.
- **CSS regenerado**: `component.css` reflete os novos aliases (`--ds-checkbox-border-radius: var(--ds-radius-sm)`, etc.).
- **8 JSONs de componente atualizados**: avatar, checkbox, radio, select, skeleton, spinner, textarea, toggle.

## Test plan

- [x] `npm run verify:tokens` → 0 errors, 0 warnings
- [x] `npm run build:tokens` sem erros
- [x] `npm run build:registry` atualizado
- [x] Figma re-audit: 0 Foundation bindings nos componentes
- [ ] Preview visual dos componentes em `docs/*.html` — zero regressão (depende da Fase 5 pra CSS consumir via camada component/semantic corretamente)

## Próximas fases

- **Fase 5**: criar 7 JSONs faltantes (alert, badge, breadcrumb, card, divider, tabs, tooltip) + atualizar 19 CSSs de componente pra consumir Semantic/Component layer (ainda consomem Foundation direto em CSS)
- **Fase 7**: enforcement em CI (3 checks: CSS leak, Figma leak, Registry completude)
- **Fase 6 final**: integração registry↔sync + docs finais

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)