### PR TITLE
fix(docs): atualizar referências de tokens órfãos no index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A partir de `1.0.0-beta.1`, o sistema entrou em **fase beta** — releases incre
 
 ## [Não publicado]
 
+### Corrigido
+- Referências órfãs de tokens de cor (`content-secondary`, `content-tertiary`) no `index.html` que causavam falha no pipeline de CI.
+
 ### Adicionado
 
 - **ADR-018 — Renomear `content.{default,secondary,tertiary}` para `content.{strong,default,subtle}`.** Único conjunto de tokens do DS com naming ordinal foi alinhado ao vocabulário descritivo das demais categorias (`border.{strong,default,subtle}`, `surface.*`, `background.*`). Strict rename — valores 100% preservados, só nomes mudaram. Migração: keys em `tokens/semantic/{light,dark}.json`, entries em `tokens/registry.json`, `--ds-content-*` em CSS de componente/base e em HTMLs/MDs de docs (sed-replace via 3 passos com placeholder pra evitar clash), Variables `content/{default,secondary,tertiary}` na collection Semantic do Figma via `use_figma` (bindings auto-seguem por ID). `npm run build:tokens` + `build:api` + `sync:docs` regeneram derivados. Decisão tomada durante #4 P1-1 da auditoria Figma↔Repo, quando `content/secondary` apareceu como text token do Badge Neutral Subtle.

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <span data-lang="pt">Início Rápido</span>
         <span data-lang="en">Quick Start</span>
       </h2>
-      <p style="color:var(--ds-content-secondary);margin-bottom:var(--ds-dimension-4);">
+      <p style="color:var(--ds-content-default);margin-bottom:var(--ds-dimension-4);">
         <span data-lang="pt">Inclua a stylesheet no seu HTML para obter todos os componentes, tokens e temas:</span>
         <span data-lang="en">Include the stylesheet in your HTML to get every component, token, and theme:</span>
       </p>
@@ -75,7 +75,7 @@
         <span data-lang="pt">Modo Escuro</span>
         <span data-lang="en">Dark Mode</span>
       </h2>
-      <p style="color:var(--ds-content-secondary);margin-bottom:var(--ds-dimension-4);">
+      <p style="color:var(--ds-content-default);margin-bottom:var(--ds-dimension-4);">
         <span data-lang="pt">Ative o modo escuro definindo o atributo <code style="font-family:var(--ds-font-family-mono);background:var(--ds-background-subtle);padding:2px 6px;border-radius:var(--ds-radius-sm);">data-mode</code> no elemento raiz:</span>
         <span data-lang="en">Enable dark mode by setting the <code style="font-family:var(--ds-font-family-mono);background:var(--ds-background-subtle);padding:2px 6px;border-radius:var(--ds-radius-sm);">data-mode</code> attribute on the root element:</span>
       </p>
@@ -90,7 +90,7 @@
           </div>
         </div>
       </div>
-      <p style="color:var(--ds-content-tertiary);font-size:var(--ds-body-font-size-sm);">
+      <p style="color:var(--ds-content-subtle);font-size:var(--ds-body-font-size-sm);">
         <span data-lang="pt">O modo claro é o padrão. Todos os tokens semânticos são remapeados automaticamente quando o modo muda.</span>
         <span data-lang="en">Light mode is the default. All semantic tokens automatically remap when the mode changes.</span>
       </p>
@@ -104,7 +104,7 @@
       <span data-lang="pt">Componentes</span>
       <span data-lang="en">Components</span>
     </h2>
-    <p style="color:var(--ds-content-secondary);margin-bottom:var(--ds-dimension-6);">
+    <p style="color:var(--ds-content-default);margin-bottom:var(--ds-dimension-6);">
       <span data-lang="pt">19 componentes prontos para produção. Clique em qualquer card para ver a documentação.</span>
       <span data-lang="en">19 production-ready components. Click any card to view its documentation.</span>
     </p>


### PR DESCRIPTION
Este PR corrige as referências órfãs de tokens de cor (`--ds-content-secondary` e `--ds-content-tertiary`) no arquivo `index.html`. 

Essas referências estavam causando falhas sistemáticas no pipeline de CI (GitHub Actions) tanto no workflow de `Test` quanto no de `Build and Deploy`, pois o script `test-css-references.mjs` valida a existência de todas as variáveis utilizadas.

**Mudanças:**
- `content-secondary` → `content-default`
- `content-tertiary` → `content-subtle`

Aprovado via `npm run verify:tokens` local.