### PR TITLE
docs(elevation): remover nomes dos níveis

### DIFF
--- a/docs/foundations-elevation.html
+++ b/docs/foundations-elevation.html
@@ -67,23 +67,23 @@
           <td><span data-lang="pt">Estado plano/reset de sombra.</span><span data-lang="en">Flat state/shadow reset.</span></td>
         </tr>
         <tr>
-          <td><strong><span data-lang="pt">1 -- Sutil</span><span data-lang="en">1 -- Subtle</span></strong></td>
+          <td><strong>1</strong></td>
           <td><code>elevation/1</code></td>
           <td><code>.ds-elevation-1</code></td>
           <td><code>--ds-shadow-sm</code></td>
           <td><code>--ds-surface-raised</code></td>
-          <td><span data-lang="pt">Elevação sutil para cards, painéis e sticky headers.</span><span data-lang="en">Subtle elevation for cards, panels, and sticky headers.</span></td>
+          <td><span data-lang="pt">Cards, painéis e sticky headers.</span><span data-lang="en">Cards, panels, and sticky headers.</span></td>
         </tr>
         <tr>
-          <td><strong><span data-lang="pt">2 -- Elevado</span><span data-lang="en">2 -- Elevated</span></strong></td>
+          <td><strong>2</strong></td>
           <td><code>elevation/2</code></td>
           <td><code>.ds-elevation-2</code></td>
           <td><code>--ds-shadow-md</code></td>
           <td><code>--ds-surface-overlay</code></td>
-          <td>Dropdowns, popovers, FABs.</td>
+          <td><span data-lang="pt">Dropdowns, popovers e FABs.</span><span data-lang="en">Dropdowns, popovers, and FABs.</span></td>
         </tr>
         <tr>
-          <td><strong><span data-lang="pt">3 -- Flutuante</span><span data-lang="en">3 -- Floating</span></strong></td>
+          <td><strong>3</strong></td>
           <td><code>elevation/3</code></td>
           <td><code>.ds-elevation-3</code></td>
           <td><code>--ds-shadow-lg</code></td>
@@ -91,7 +91,7 @@
           <td><span data-lang="pt">Sidesheets e painéis flutuantes.</span><span data-lang="en">Sidesheets and floating panels.</span></td>
         </tr>
         <tr>
-          <td><strong><span data-lang="pt">4 -- Destaque</span><span data-lang="en">4 -- Prominent</span></strong></td>
+          <td><strong>4</strong></td>
           <td><code>elevation/4</code></td>
           <td><code>.ds-elevation-4</code></td>
           <td><code>--ds-shadow-xl</code></td>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1466,7 +1466,7 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 
 | Coleção | Tokens | Status |
 |---------|--------|--------|
-| Foundation | 267 | 🟢 |
+| Foundation | 265 | 🟢 |
 | Semantic (light) | 173 | 🟢 |
 | Semantic (dark) | 173 | 🟢 |
 
@@ -8465,10 +8465,10 @@ Seção expandida com contexto, decisão e locais de uso.
 
 | Camada | Tokens | Arquivos |
 |--------|--------|----------|
-| Foundation | **267** | 9 |
+| Foundation | **265** | 9 |
 | Semantic | **173 × 2 modos** | light.json + dark.json |
 
-## Foundation (267 tokens)
+## Foundation (265 tokens)
 
 | Arquivo | Tokens |
 |---------|--------|
@@ -8477,7 +8477,7 @@ Seção expandida com contexto, decisão e locais de uso.
 | `motion.json` | 10 |
 | `opacity.json` | 6 |
 | `radius.json` | 7 |
-| `shadows.json` | 7 |
+| `shadows.json` | 5 |
 | `stroke.json` | 3 |
 | `typography.json` | 54 |
 | `z-index.json` | 6 |


### PR DESCRIPTION
## Contexto

A documentação de Elevation estava exibindo nomes descritivos junto aos níveis numéricos, como "1 -- Sutil" e "2 -- Elevado". Esses nomes não existem como contrato no Figma nem no JSON; a escala oficial é numérica: elevation/0 a elevation/4.

## Alterações

- Mantém a coluna Nível apenas com 0, 1, 2, 3 e 4.
- Move a descrição para a coluna de papel/uso, sem tratar essa descrição como nome oficial.
- Regenera docs/llms-full.txt para refletir os totais atuais de shadow/elevation.

## Validação

- npm run verify:tokens
- git diff --check