### PR TITLE
docs: normalizar estrutura da documentação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A partir de `1.0.0-beta.1`, o sistema entrou em **fase beta** — releases incre
 ## [Não publicado]
 
 ### Corrigido
+- **Documentação normalizada conforme auditoria estrutural.** Labels de tabela foram padronizados (`Variável CSS`, `Descrição`, `Critério WCAG`, `Função`, `Referência`), README atualizado para 18 ADRs, páginas simples de componentes ganharam anatomia curta, `Form Field` declara o contrato CSS-only na própria página, e referências stale a `semantic.content.secondary/tertiary` foram migradas para `semantic.content.default/subtle`.
 - **Escala de Elevation/Shadow oficializada em 4 níveis + reset.** Removidos `foundation.shadow.xs` e `foundation.shadow.2xl` por não terem uso nem Effect Style correspondente. `foundation.shadow.{sm,md,lg,xl}` preserva exatamente os parâmetros dos Effect Styles Figma `elevation/1..4`, e `foundation.shadow.none` permanece como reset técnico de `.ds-elevation-0`. A página de Elevation agora documenta o papel de cada nível e o mapping Figma ↔ CSS. Resolve #19 / P3-2 da auditoria Figma↔Repo.
 - **Documentação de Elevation mantém nomes oficiais numéricos.** A tabela de `foundations-elevation.html` agora mostra apenas os níveis `0` a `4` como nomes oficiais, sem rótulos descritivos não existentes no Figma/JSON.
 - **Documentação de Elevation separa conceito de utility CSS.** A tabela principal agora segue o padrão de Foundation (`Nível`, Figma, sombra, surface recomendada e papel), enquanto `.ds-elevation-*` fica documentado como utility auxiliar que aplica apenas `box-shadow`.
@@ -49,6 +50,7 @@ A partir de `1.0.0-beta.1`, o sistema entrou em **fase beta** — releases incre
 
 ### Adicionado
 
+- **Guia editorial de documentação** (`docs/documentation-guidelines.md`). Define templates para páginas Foundation, Component, Process e System, exceções permitidas, labels oficiais de tabela e regra authored vs generated.
 - **Auditoria estrutural da documentação** (`audit/docs-structure-audit.md`). Classifica páginas por tipo (Foundation, Component, Process, System), identifica inconsistências editoriais e define uma sequência recomendada de PRs para normalização.
 
 - **ADR-018 — Renomear `content.{default,secondary,tertiary}` para `content.{strong,default,subtle}`.** Único conjunto de tokens do DS com naming ordinal foi alinhado ao vocabulário descritivo das demais categorias (`border.{strong,default,subtle}`, `surface.*`, `background.*`). Strict rename — valores 100% preservados, só nomes mudaram. Migração: keys em `tokens/semantic/{light,dark}.json`, entries em `tokens/registry.json`, `--ds-content-*` em CSS de componente/base e em HTMLs/MDs de docs (sed-replace via 3 passos com placeholder pra evitar clash), Variables `content/{default,secondary,tertiary}` na collection Semantic do Figma via `use_figma` (bindings auto-seguem por ID). `npm run build:tokens` + `build:api` + `sync:docs` regeneram derivados. Decisão tomada durante #4 P1-1 da auditoria Figma↔Repo, quando `content/secondary` apareceu como text token do Badge Neutral Subtle.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ Depois serve o diretório estático (`python3 -m http.server` ou equivalente).
 
 ## Documentação completa
 
-Toda a documentação vive em **[uxindesign.github.io/design-system-core](https://uxindesign.github.io/design-system-core/)**. Lá estão: 19 componentes com preview ao vivo, 10 foundations, guias de tema e acessibilidade, 15 ADRs navegáveis, inventário de tokens, e consumo por IA em `/docs/llms.txt`.
+Toda a documentação vive em **[uxindesign.github.io/design-system-core](https://uxindesign.github.io/design-system-core/)**. Lá estão: 19 componentes com preview ao vivo, 10 foundations, guias de tema, acessibilidade e documentação, 18 ADRs navegáveis, inventário de tokens, e consumo por IA em `/docs/llms.txt`.
 
 Links rápidos:
 
 - [Getting Started](https://uxindesign.github.io/design-system-core/index.html)
 - [Token Architecture](https://uxindesign.github.io/design-system-core/docs/token-architecture.html)
+- [Documentation Guidelines](https://uxindesign.github.io/design-system-core/docs/documentation-guidelines.html)
 - [Component Inventory](./docs/component-inventory.md)
 - [Decisões (ADRs)](./docs/decisions/)
 - [Changelog](./CHANGELOG.md)

--- a/audit/docs-structure-audit.md
+++ b/audit/docs-structure-audit.md
@@ -10,6 +10,18 @@ A documentação tem boa cobertura funcional, mas ainda não tem uma convenção
 
 O problema não é que todas as páginas sejam diferentes. Foundations, Components, Process e System pages têm finalidades diferentes e devem ter estruturas diferentes. O problema é que essa diferença ainda não está documentada como contrato editorial.
 
+## Status de execução (2026-05-08)
+
+| Achado | Status | Evidência |
+|---|---|---|
+| `brand-principles` é placeholder público | Pendente por decisão | Fora deste ajuste a pedido do usuário. |
+| Contrato editorial versionado | Concluído | `docs/documentation-guidelines.md` + página publicada em `docs/documentation-guidelines.html`. |
+| Labels de tabelas variam | Concluído | Labels normalizados para `Variável CSS`, `Descrição`, `Critério WCAG`, `Função` e `Referência`. |
+| Component pages com exceções não declaradas | Concluído | `Avatar`, `Divider`, `Skeleton` e `Spinner` ganharam anatomia curta; `Form Field` declara o contrato CSS-only e suas relações. |
+| Entry points com metadados stale | Concluído | `README.md` atualizado para 18 ADRs e link para o guia editorial. |
+| Generated vs authored pouco óbvio | Concluído | Guia editorial documenta páginas authored/generated e comandos de regeneração. |
+| Nome do produto | Concluído | Guia editorial fixa `Design System Core` como nome do projeto; `Design System` fica restrito a label visual curta do shell. |
+
 ## Metodologia
 
 Leituras e verificações feitas nesta sessão:
@@ -303,4 +315,3 @@ Escopo:
 - Carbon Design System: componentes separam Usage, Style, Code e Accessibility; specs visuais detalham element/property/token.
 
 Esses benchmarks não devem ser copiados literalmente. Eles sustentam a separação editorial entre Foundations, Components e Process/System pages.
-

--- a/docs/accessibility.html
+++ b/docs/accessibility.html
@@ -96,7 +96,7 @@
           <tr>
             <th style="text-align:left;padding:var(--ds-dimension-8) var(--ds-dimension-12);border-bottom:var(--ds-border-width-2) solid var(--ds-border-default);"><span data-lang="pt">Tipo de elemento</span><span data-lang="en">Element Type</span></th>
             <th style="text-align:left;padding:var(--ds-dimension-8) var(--ds-dimension-12);border-bottom:var(--ds-border-width-2) solid var(--ds-border-default);"><span data-lang="pt">Ratio mínimo</span><span data-lang="en">Minimum Ratio</span></th>
-            <th style="text-align:left;padding:var(--ds-dimension-8) var(--ds-dimension-12);border-bottom:var(--ds-border-width-2) solid var(--ds-border-default);"><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG Criterion</span></th>
+            <th style="text-align:left;padding:var(--ds-dimension-8) var(--ds-dimension-12);border-bottom:var(--ds-border-width-2) solid var(--ds-border-default);"><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG Criterion</span></th>
           </tr>
         </thead>
         <tbody>

--- a/docs/alert.html
+++ b/docs/alert.html
@@ -100,7 +100,7 @@
       <strong>2</strong> Ícone (<code>.ds-alert__icon</code>) — Material Symbol específico do tipo, reforça o significado além da cor.<br>
       <strong>3</strong> Conteúdo (<code>.ds-alert__content</code>) — wrapper para título e descricao.<br>
       <strong>4</strong> Título (<code>.ds-alert__title</code>) — negrito, 1-3 palavras.<br>
-      <strong>5</strong> Descricao (<code>.ds-alert__description</code>) — o que aconteceu + o que fazer.<br>
+      <strong>5</strong> Descrição (<code>.ds-alert__description</code>) — o que aconteceu + o que fazer.<br>
       <strong>6</strong> Fechar (<code>.ds-alert__close</code>) — button de dispensar com <code>aria-label="Dismiss alert"</code>.</span><span data-lang="en"><strong>1</strong> Container (<code>.ds-alert</code>) — background, border-radius, padding.<br>
       <strong>2</strong> Icon (<code>.ds-alert__icon</code>) — type-specific Material Symbol, reinforces meaning beyond color.<br>
       <strong>3</strong> Content (<code>.ds-alert__content</code>) — wrapper for title and description.<br>
@@ -420,7 +420,7 @@
       <thead><tr><th><span data-lang="pt">Regra</span><span data-lang="en">Rule</span></th><th><span data-lang="pt">Exemplo</span><span data-lang="en">Example</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">Título: 1-3 palavras, sentence case</span><span data-lang="en">Title: 1-3 words, sentence case</span></td><td>"Payment failed", "Changes saved"</td></tr>
-        <tr><td><span data-lang="pt">Descricao: o que aconteceu + o que fazer</span><span data-lang="en">Description: what happened + what to do</span></td><td>"Your session expired. Please log in again."</td></tr>
+        <tr><td><span data-lang="pt">Descrição: o que aconteceu + o que fazer</span><span data-lang="en">Description: what happened + what to do</span></td><td>"Your session expired. Please log in again."</td></tr>
         <tr><td><span data-lang="pt">Button de fechar deve ter <code>aria-label</code></span><span data-lang="en">Close button must have <code>aria-label</code></span></td><td><code>aria-label="Dismiss alert"</code></td></tr>
       </tbody>
     </table>
@@ -435,14 +435,14 @@
       <span data-lang="pt">Tokens mostrados para a variante success. Outros tipos (warning, error, info) seguem o mesmo padrão com seus respectivos grupos de cor de feedback.</span><span data-lang="en">Tokens shown for the success variant. Other types (warning, error, info) follow the same pattern with their respective feedback color groups.</span>
     </p>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>bg (success filled)</td><td><code>semantic.feedback.success.bg-default</code></td><td><code>--ds-feedback-success-background-default</code></td></tr>
         <tr><td>bg (success subtle)</td><td><code>semantic.feedback.success.bg-subtle</code></td><td><code>--ds-feedback-success-background-subtle</code></td></tr>
         <tr><td>border (success subtle)</td><td><code>semantic.feedback.success.border-default</code></td><td><code>--ds-feedback-success-border-default</code></td></tr>
         <tr><td>text (success filled)</td><td><code>semantic.feedback.success.content-contrast</code></td><td><code>--ds-feedback-success-content-contrast</code></td></tr>
         <tr><td>text title (subtle)</td><td><code>semantic.content.default</code></td><td><code>--ds-content-strong</code></td></tr>
-        <tr><td>text description (subtle)</td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>text description (subtle)</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-md</code></td></tr>
         <tr><td>padding (all sides)</td><td><code>foundation.spacing.48</code></td><td><code>--ds-dimension-12</code></td></tr>
         <tr><td>gap</td><td><code>foundation.spacing.32</code></td><td><code>--ds-dimension-8</code></td></tr>
@@ -458,7 +458,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-alert</code></td><td><span data-lang="pt">Container base do alert</span><span data-lang="en">Base alert container</span></td></tr>
         <tr><td><code>ds-alert--filled</code></td><td><span data-lang="pt">Estilo com fundo preenchido (solid)</span><span data-lang="en">Filled/solid background style</span></td></tr>
@@ -497,7 +497,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>4.1.3 Status Messages (AA)</td><td><span data-lang="pt"><code>role="alert"</code> para mensagens urgentes, <code>role="status"</code> para não urgentes</span><span data-lang="en"><code>role="alert"</code> for urgent messages, <code>role="status"</code> for non-urgent</span></td><td>&#10003;</td></tr>
         <tr><td>1.4.1 Use of Color (A)</td><td><span data-lang="pt">Ícone + texto complementam a cor — nunca cor sozinha</span><span data-lang="en">Icon + text supplement color — never color alone</span></td><td>&#10003;</td></tr>

--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -60,7 +60,22 @@
   </div>
 
   <!-- ============================================================
-       3. VARIANTS (live previews)
+       3. ANATOMY
+       ============================================================ -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Anatomia</span><span data-lang="en">Anatomy</span></h2>
+    <div class="ds-anatomy-legend">
+      <span data-lang="pt"><strong>1</strong> Container (<code>.ds-avatar</code>) — círculo com tamanho fixo e overflow controlado.<br>
+      <strong>2</strong> Conteúdo — imagem, iniciais ou ícone de fallback.<br>
+      <strong>3</strong> Size modifier — <code>--sm</code>, <code>--md</code> ou <code>--lg</code>, alinhado à escala de size do DS.</span>
+      <span data-lang="en"><strong>1</strong> Container (<code>.ds-avatar</code>) — circle with fixed size and controlled overflow.<br>
+      <strong>2</strong> Content — image, initials, or fallback icon.<br>
+      <strong>3</strong> Size modifier — <code>--sm</code>, <code>--md</code>, or <code>--lg</code>, aligned to the DS size scale.</span>
+    </div>
+  </div>
+
+  <!-- ============================================================
+       4. VARIANTS (live previews)
        ============================================================ -->
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Avatar com iniciais</span><span data-lang="en">Initials avatar</span></h2>
@@ -204,7 +219,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">fundo (fallback)</span><span data-lang="en">background (fallback)</span></td><td><code>semantic.primary.background.default</code></td><td><code>--ds-primary-background-default</code></td></tr>
         <tr><td><span data-lang="pt">texto (iniciais)</span><span data-lang="en">text (initials)</span></td><td><code>semantic.primary.content-default</code></td><td><code>--ds-primary-content-default</code></td></tr>
@@ -219,7 +234,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-avatar</code></td><td><span data-lang="pt">Classe base do avatar</span><span data-lang="en">Base avatar class</span></td></tr>
         <tr><td><code>ds-avatar--sm</code></td><td><span data-lang="pt">Tamanho pequeno (32px)</span><span data-lang="en">Small size (32px)</span></td></tr>

--- a/docs/badge.html
+++ b/docs/badge.html
@@ -217,7 +217,7 @@
       <span data-lang="pt">Tokens mostrados para a variante primary. Outras variantes de cor seguem o mesmo padrão com seus respectivos grupos de cor.</span><span data-lang="en">Tokens shown for the primary variant. Other color variants follow the same pattern with their respective color groups.</span>
     </p>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>bg (primary solid)</td><td><code>semantic.primary.background.default</code></td><td><code>--ds-primary-background-default</code></td></tr>
         <tr><td>text (primary solid)</td><td><code>semantic.primary.content-default</code></td><td><code>--ds-primary-content-default</code></td></tr>
@@ -234,7 +234,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-badge</code></td><td><span data-lang="pt">Classe base do badge</span><span data-lang="en">Base badge class</span></td></tr>
         <tr><td><code>ds-badge--solid</code></td><td><span data-lang="pt">Estilo preenchido (solid)</span><span data-lang="en">Solid filled style</span></td></tr>
@@ -266,7 +266,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>1.4.1 Use of Color (A)</td><td><span data-lang="pt">O texto transmite o significado, não apenas a cor</span><span data-lang="en">Text conveys meaning, not color alone</span></td><td>&#10003;</td></tr>
         <tr><td>1.4.3 Contrast (AA)</td><td><span data-lang="pt">Todas as combinacoes de cores atendem ao ratio de contraste 4.5:1</span><span data-lang="en">All color combinations meet 4.5:1 contrast ratio</span></td><td>&#10003;</td></tr>

--- a/docs/breadcrumb.html
+++ b/docs/breadcrumb.html
@@ -253,12 +253,12 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">cor do link</span><span data-lang="en">link color</span></td><td><code>semantic.link.content-default</code></td><td><code>--ds-link-content-default</code></td></tr>
         <tr><td><span data-lang="pt">link hover</span><span data-lang="en">link hover</span></td><td>—</td><td><span data-lang="pt"><code>text-decoration: underline</code> (sem mudança de cor)</span><span data-lang="en"><code>text-decoration: underline</code> (no color change)</span></td></tr>
         <tr><td><span data-lang="pt">texto atual</span><span data-lang="en">current text</span></td><td><code>semantic.content.default</code></td><td><code>--ds-content-strong</code></td></tr>
-        <tr><td><span data-lang="pt">separador</span><span data-lang="en">separator</span></td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-subtle</code></td></tr>
+        <tr><td><span data-lang="pt">separador</span><span data-lang="en">separator</span></td><td><code>semantic.content.subtle</code></td><td><code>--ds-content-subtle</code></td></tr>
       </tbody>
     </table>
   </div>
@@ -269,7 +269,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-breadcrumb</code></td><td><span data-lang="pt">Container do breadcrumb (use em <code>&lt;nav&gt;</code>)</span><span data-lang="en">Breadcrumb container (use on <code>&lt;nav&gt;</code>)</span></td></tr>
         <tr><td><code>ds-breadcrumb__item</code></td><td><span data-lang="pt">Link ou texto individual do breadcrumb</span><span data-lang="en">Individual breadcrumb link or text</span></td></tr>
@@ -302,7 +302,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>1.3.1 Info and Relationships (A)</td><td><span data-lang="pt">Landmark <code>&lt;nav&gt;</code> com <code>aria-label="Breadcrumb"</code>. Usa <code>&lt;ol&gt;</code> para estrutura semantica de lista.</span><span data-lang="en"><code>&lt;nav&gt;</code> landmark with <code>aria-label="Breadcrumb"</code>. Uses <code>&lt;ol&gt;</code> for semantic list structure.</span></td><td>&#10003;</td></tr>
         <tr><td>2.4.8 Location (AAA)</td><td><span data-lang="pt">Comunica a localização atual do usuário dentro da hierarquia do site.</span><span data-lang="en">Communicates user's current location within the site hierarchy.</span></td><td>&#10003;</td></tr>

--- a/docs/card.html
+++ b/docs/card.html
@@ -313,7 +313,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>background</td><td><code>semantic.surface.default</code></td><td><code>--ds-surface-default</code></td></tr>
         <tr><td>background (elevated variant)</td><td><code>semantic.surface.raised</code></td><td><code>--ds-surface-raised</code></td></tr>
@@ -333,7 +333,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-card</code></td><td><span data-lang="pt">Container base do card</span><span data-lang="en">Base card container</span></td></tr>
         <tr><td><code>ds-card--default</code></td><td><span data-lang="pt">Variante padrão com borda sutil</span><span data-lang="en">Default variant with subtle border</span></td></tr>
@@ -363,7 +363,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>1.4.11 Non-text Contrast (AA)</td><td><span data-lang="pt">Borda ou sombra deve ter pelo menos 3:1 de contraste com o fundo da página</span><span data-lang="en">Border or shadow must have at least 3:1 contrast against the page background</span></td><td>&#10003;</td></tr>
         <tr><td>2.5.8 Target Size min (AA)</td><td><span data-lang="pt">Se o card for clicável, toda a superfície deve ser o alvo de clique</span><span data-lang="en">If the card is clickable, the entire surface must be the click target</span></td><td>&#10003;</td></tr>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -72,6 +72,8 @@
 <h2><a href="https://github.com/uxindesign/design-system-core/compare/v0.5.0-pre-consolidation...HEAD">Não publicado</a></h2>
 <h3>Corrigido</h3>
 <ul>
+<li><p><strong>Documentação normalizada conforme auditoria estrutural.</strong> Labels de tabela foram padronizados (<code>Variável CSS</code>, <code>Descrição</code>, <code>Critério WCAG</code>, <code>Função</code>, <code>Referência</code>), README atualizado para 18 ADRs, páginas simples de componentes ganharam anatomia curta, <code>Form Field</code> declara o contrato CSS-only na própria página, e referências stale a <code>semantic.content.secondary/tertiary</code> foram migradas para <code>semantic.content.default/subtle</code>.</p>
+</li>
 <li><p><strong>Escala de Elevation/Shadow oficializada em 4 níveis + reset.</strong> Removidos <code>foundation.shadow.xs</code> e <code>foundation.shadow.2xl</code> por não terem uso nem Effect Style correspondente. <code>foundation.shadow.{sm,md,lg,xl}</code> preserva exatamente os parâmetros dos Effect Styles Figma <code>elevation/1..4</code>, e <code>foundation.shadow.none</code> permanece como reset técnico de <code>.ds-elevation-0</code>. A página de Elevation agora documenta o papel de cada nível e o mapping Figma ↔ CSS. Resolve #19 / P3-2 da auditoria Figma↔Repo.</p>
 </li>
 <li><p><strong>Documentação de Elevation mantém nomes oficiais numéricos.</strong> A tabela de <code>foundations-elevation.html</code> agora mostra apenas os níveis <code>0</code> a <code>4</code> como nomes oficiais, sem rótulos descritivos não existentes no Figma/JSON.</p>
@@ -130,6 +132,8 @@
 </ul>
 <h3>Adicionado</h3>
 <ul>
+<li><p><strong>Guia editorial de documentação</strong> (<code>docs/documentation-guidelines.md</code>). Define templates para páginas Foundation, Component, Process e System, exceções permitidas, labels oficiais de tabela e regra authored vs generated.</p>
+</li>
 <li><p><strong>Auditoria estrutural da documentação</strong> (<code>audit/docs-structure-audit.md</code>). Classifica páginas por tipo (Foundation, Component, Process, System), identifica inconsistências editoriais e define uma sequência recomendada de PRs para normalização.</p>
 </li>
 <li><p><strong>ADR-018 — Renomear <code>content.{default,secondary,tertiary}</code> para <code>content.{strong,default,subtle}</code>.</strong> Único conjunto de tokens do DS com naming ordinal foi alinhado ao vocabulário descritivo das demais categorias (<code>border.{strong,default,subtle}</code>, <code>surface.*</code>, <code>background.*</code>). Strict rename — valores 100% preservados, só nomes mudaram. Migração: keys em <code>tokens/semantic/{light,dark}.json</code>, entries em <code>tokens/registry.json</code>, <code>--ds-content-*</code> em CSS de componente/base e em HTMLs/MDs de docs (sed-replace via 3 passos com placeholder pra evitar clash), Variables <code>content/{default,secondary,tertiary}</code> na collection Semantic do Figma via <code>use_figma</code> (bindings auto-seguem por ID). <code>npm run build:tokens</code> + <code>build:api</code> + <code>sync:docs</code> regeneram derivados. Decisão tomada durante #4 P1-1 da auditoria Figma↔Repo, quando <code>content/secondary</code> apareceu como text token do Badge Neutral Subtle.</p>

--- a/docs/divider.html
+++ b/docs/divider.html
@@ -60,7 +60,22 @@
   </div>
 
   <!-- ============================================================
-       3. VARIANTS (live previews)
+       3. ANATOMY
+       ============================================================ -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Anatomia</span><span data-lang="en">Anatomy</span></h2>
+    <div class="ds-anatomy-legend">
+      <span data-lang="pt"><strong>1</strong> Elemento separador (<code>.ds-divider</code>) — <code>&lt;hr&gt;</code> decorativo ou elemento com <code>role="separator"</code> quando semântico.<br>
+      <strong>2</strong> Orientação — horizontal por padrão; vertical com <code>.ds-divider--vertical</code>.<br>
+      <strong>3</strong> Token de borda — usa cor semântica de divider/border, não cor hardcoded.</span>
+      <span data-lang="en"><strong>1</strong> Separator element (<code>.ds-divider</code>) — decorative <code>&lt;hr&gt;</code> or element with <code>role="separator"</code> when semantic.<br>
+      <strong>2</strong> Orientation — horizontal by default; vertical with <code>.ds-divider--vertical</code>.<br>
+      <strong>3</strong> Border token — uses semantic divider/border color, not hardcoded color.</span>
+    </div>
+  </div>
+
+  <!-- ============================================================
+       4. VARIANTS (live previews)
        ============================================================ -->
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Divider horizontal</span><span data-lang="en">Horizontal divider</span></h2>
@@ -223,7 +238,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">cor</span><span data-lang="en">color</span></td><td><code>semantic.border.default</code></td><td><code>--ds-border-default</code></td></tr>
         <tr><td><span data-lang="pt">largura</span><span data-lang="en">width</span></td><td><code>foundation.border.width.1</code></td><td><code>--ds-border-width-1</code></td></tr>
@@ -237,7 +252,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-divider</code></td><td><span data-lang="pt">Divider horizontal (padrão)</span><span data-lang="en">Horizontal divider (default)</span></td></tr>
         <tr><td><code>ds-divider--vertical</code></td><td><span data-lang="pt">Divider vertical (para flex containers)</span><span data-lang="en">Vertical divider (for flex containers)</span></td></tr>

--- a/docs/documentation-guidelines.html
+++ b/docs/documentation-guidelines.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Documentation guidelines — Design System</title>
+  <link rel="stylesheet" href="../css/design-system.css">
+  <link rel="stylesheet" href="layout.css">
+  <style>
+    .ds-md-content h1, .ds-md-content h2, .ds-md-content h3 { margin-top: var(--ds-dimension-32); margin-bottom: var(--ds-dimension-12); color: var(--ds-content-default); }
+    .ds-md-content h1 { font-size: var(--ds-body-font-size-2xl); font-weight: var(--ds-body-font-weight-semibold); margin-top: 0; }
+    .ds-md-content h2 { font-size: var(--ds-body-font-size-xl); font-weight: var(--ds-body-font-weight-semibold); border-top: var(--ds-border-width-1) solid var(--ds-border-subtle); padding-top: var(--ds-dimension-24); }
+    .ds-md-content h3 { font-size: var(--ds-body-font-size-lg); font-weight: var(--ds-body-font-weight-semibold); }
+    .ds-md-content p { color: var(--ds-content-default); line-height: var(--ds-body-line-height-md); margin: var(--ds-dimension-12) 0; }
+    .ds-md-content ul, .ds-md-content ol { color: var(--ds-content-default); line-height: var(--ds-body-line-height-md); padding-left: var(--ds-dimension-24); margin: var(--ds-dimension-12) 0; }
+    .ds-md-content li { margin: var(--ds-dimension-4) 0; }
+    .ds-md-content code { font-family: var(--ds-font-family-mono); font-size: 0.9em; background: var(--ds-background-subtle); color: var(--ds-link-content-default); padding: 1px var(--ds-dimension-4); border-radius: var(--ds-radius-sm); }
+    .ds-md-content pre { background: var(--ds-background-inverse); color: var(--ds-content-inverse); padding: var(--ds-dimension-16); border-radius: var(--ds-radius-md); overflow-x: auto; font-size: var(--ds-body-font-size-sm); margin: var(--ds-dimension-16) 0; }
+    .ds-md-content pre code { background: none; color: inherit; padding: 0; }
+    .ds-md-content table { width: 100%; border-collapse: collapse; margin: var(--ds-dimension-16) 0; font-size: var(--ds-body-font-size-sm); }
+    .ds-md-content table th, .ds-md-content table td { text-align: left; padding: var(--ds-dimension-8) var(--ds-dimension-12); border-bottom: var(--ds-border-width-1) solid var(--ds-border-default); }
+    .ds-md-content table th { font-weight: var(--ds-body-font-weight-semibold); background: var(--ds-background-subtle); }
+    .ds-md-content a { color: var(--ds-link-content-default); }
+    .ds-md-content a:hover { color: var(--ds-link-content-hover); }
+    .ds-md-content blockquote { border-left: 3px solid var(--ds-border-default); margin: var(--ds-dimension-16) 0; padding: var(--ds-dimension-8) var(--ds-dimension-16); color: var(--ds-content-subtle); font-style: italic; }
+    .ds-md-content hr { border: none; border-top: var(--ds-border-width-1) solid var(--ds-border-subtle); margin: var(--ds-dimension-32) 0; }
+    .ds-md-content strong { color: var(--ds-content-default); }
+    .ds-md-generated-banner { background: var(--ds-feedback-info-background-subtle); color: var(--ds-feedback-info-content-default); border: var(--ds-border-width-default) solid var(--ds-feedback-info-border-default); padding: var(--ds-dimension-12) var(--ds-dimension-20); border-radius: var(--ds-radius-md); margin-bottom: var(--ds-dimension-24); font-size: var(--ds-body-font-size-sm); }
+    .ds-md-generated-banner code { background: var(--ds-surface-default); color: var(--ds-feedback-info-content-default); padding: 1px var(--ds-dimension-6); border-radius: var(--ds-radius-sm); font-family: var(--ds-font-family-mono); border: var(--ds-border-width-default) solid var(--ds-feedback-info-border-default); }
+  </style>
+  <script>
+    (function(){var l=localStorage.getItem('ds-lang');if(l)document.documentElement.setAttribute('lang',l)})();
+  </script>
+</head>
+<body>
+
+<header class="ds-site-header">
+  <div style="display:flex;align-items:center;gap:var(--ds-dimension-16)">
+    <button class="ds-menu-toggle" id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+    </button>
+    <a href="../index.html" class="ds-site-header__brand">
+      <div class="ds-site-header__logo">DS</div>
+      <span class="ds-site-header__title">Design System</span>
+    </a>
+  </div>
+  <div class="ds-site-header__actions">
+    <select class="ds-theme-switcher__select" id="lang-switcher" aria-label="Language">
+      <option value="pt">PT</option>
+      <option value="en">EN</option>
+    </select>
+    <button class="ds-btn ds-btn--ghost ds-btn--sm" id="mode-toggle" aria-pressed="false" aria-label="Toggle dark mode"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26 5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg> Dark</button>
+  </div>
+</header>
+<div class="ds-sidebar-overlay" id="sidebar-overlay"></div>
+<nav class="ds-sidebar" id="sidebar" aria-label="Main navigation"></nav>
+
+<main class="ds-main">
+  <div class="ds-section">
+    <h1 class="ds-section__title">Documentation guidelines</h1>
+    <p class="ds-section__subtitle">Templates editoriais para páginas de Foundation, Component, Process e System.</p>
+  </div>
+
+  <div class="ds-md-generated-banner">
+    Este arquivo é gerado automaticamente por <code>scripts/sync-docs.mjs</code>. Editar a fonte original, não este HTML.
+  </div>
+
+  <div class="ds-md-content">
+<p>Este guia define o contrato editorial das páginas do Design System Core. Use-o antes de criar, refatorar ou revisar páginas em <code>docs/</code>.</p>
+<h2>Princípios</h2>
+<ol>
+<li><strong>Docs descrevem o estado atual.</strong> A fonte de verdade continua sendo ADR, Figma, JSON e CSS conforme <code>AGENTS.md</code>.</li>
+<li><strong>Estrutura varia por finalidade.</strong> Foundation, Component, Process e System pages não precisam ter o mesmo template.</li>
+<li><strong>Exceções devem ser explícitas.</strong> Se uma página omite uma seção comum, explique o motivo na própria página ou neste guia.</li>
+<li><strong>Nomes oficiais não são inventados na documentação.</strong> Use o nome do Figma, JSON ou CSS. Descrições de uso ficam em colunas de papel/uso.</li>
+<li><strong>Design System Core é o nome do projeto.</strong> Enquanto não houver nome de produto final, não usar outro nome para o DS.</li>
+</ol>
+<h2>Tipos de página</h2>
+<table>
+<thead>
+<tr>
+<th>Tipo</th>
+<th>Finalidade</th>
+<th>Exemplos</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Foundation</td>
+<td>Explicar escalas, tokens, valores e uso recomendado</td>
+<td>Colors, Spacing, Elevation</td>
+</tr>
+<tr>
+<td>Component</td>
+<td>Ensinar uso, anatomia, estados, tokens, CSS e acessibilidade</td>
+<td>Button, Input, Tabs</td>
+</tr>
+<tr>
+<td>Process</td>
+<td>Explicar fluxo operacional verificável</td>
+<td>Contributing, Releasing, Versioning</td>
+</tr>
+<tr>
+<td>System</td>
+<td>Explicar princípios, arquitetura e normas transversais</td>
+<td>Token Architecture, Accessibility</td>
+</tr>
+</tbody></table>
+<h2>Foundation pages</h2>
+<p>Template recomendado:</p>
+<ol>
+<li>Visão geral.</li>
+<li>Visual reference ou escala.</li>
+<li>Token reference.</li>
+<li>Uso e relações com outros sistemas, quando aplicável.</li>
+<li>Exceções arquiteturais, quando houver ADR.</li>
+<li>JSON (DTCG).</li>
+</ol>
+<p>Variações permitidas:</p>
+<ul>
+<li>Colors e Theme Colors podem usar swatches em vez de tabelas.</li>
+<li>Typography pode incluir preview de tipo.</li>
+<li>Elevation deve mencionar surface, porque depth combina shadow e surface, especialmente em dark mode.</li>
+<li>Motion, Z-index e Shadow/Elevation podem citar exceções CSS-only quando ligadas à ADR-016.</li>
+</ul>
+<h2>Component pages</h2>
+<p>Template recomendado:</p>
+<ol>
+<li>Quando usar.</li>
+<li>Anatomia.</li>
+<li>Variantes, tamanhos, estados e exemplos.</li>
+<li>Boas práticas.</li>
+<li>Diretrizes de conteúdo, quando o componente renderiza texto, label ou mensagem.</li>
+<li>Mapeamento de tokens.</li>
+<li>Classes CSS.</li>
+<li>Propriedades Figma, quando houver variants/properties relevantes para handoff.</li>
+<li>Interação por teclado, quando interativo.</li>
+<li>Accessibility.</li>
+<li>Relacionados.</li>
+</ol>
+<p>Exceções permitidas:</p>
+<ul>
+<li>Componentes não interativos não precisam de Interação por teclado.</li>
+<li>Componentes simples podem ter uma anatomia curta, mas não devem omitir a intenção estrutural.</li>
+<li><code>Form Field</code> segue template próprio porque é CSS-only por ADR-017.</li>
+</ul>
+<h2>Form Field</h2>
+<p><code>Form Field</code> é CSS-only e não deve ser auditado como componente visual ausente no Figma. A página deve deixar claro que:</p>
+<ul>
+<li>existe para compor markup HTML de label, control, helper e error;</li>
+<li>não substitui os componentes Figma de Input, Select, Textarea, Checkbox, Radio ou Toggle;</li>
+<li>mapeia comportamento de DOM e ARIA, não uma nova superfície visual no Figma.</li>
+</ul>
+<h2>Process pages</h2>
+<p>Template recomendado:</p>
+<ol>
+<li>Escopo e fonte de verdade.</li>
+<li>Antes de começar.</li>
+<li>Passo a passo.</li>
+<li>Validação.</li>
+<li>Falhas comuns ou rollback.</li>
+<li>Links relacionados.</li>
+</ol>
+<h2>System pages</h2>
+<p>Template recomendado:</p>
+<ol>
+<li>Princípio ou decisão.</li>
+<li>Impacto em design.</li>
+<li>Impacto em código.</li>
+<li>Tokens ou artefatos relacionados.</li>
+<li>Verificação.</li>
+<li>ADRs e processos relacionados.</li>
+</ol>
+<h2>Labels oficiais de tabelas</h2>
+<p>Use estes labels em português:</p>
+<table>
+<thead>
+<tr>
+<th>Conceito</th>
+<th>Label</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>CSS variable</td>
+<td>Variável CSS</td>
+</tr>
+<tr>
+<td>Description</td>
+<td>Descrição</td>
+</tr>
+<tr>
+<td>WCAG criterion</td>
+<td>Critério WCAG</td>
+</tr>
+<tr>
+<td>Function / role</td>
+<td>Função ou Papel</td>
+</tr>
+<tr>
+<td>Reference</td>
+<td>Referência</td>
+</tr>
+<tr>
+<td>Class</td>
+<td>Classe</td>
+</tr>
+<tr>
+<td>Property</td>
+<td>Propriedade</td>
+</tr>
+<tr>
+<td>Value</td>
+<td>Valor</td>
+</tr>
+<tr>
+<td>Usage</td>
+<td>Uso</td>
+</tr>
+</tbody></table>
+<h2>Authored vs generated</h2>
+<table>
+<thead>
+<tr>
+<th>Arquivo</th>
+<th>Tipo</th>
+<th>Como alterar</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>docs/*.html</code> manuais</td>
+<td>Authored</td>
+<td>Editar o HTML direto</td>
+</tr>
+<tr>
+<td><code>docs/*.md</code> publicados por <code>sync:docs</code></td>
+<td>Authored source</td>
+<td>Editar o MD e rodar <code>npm run sync:docs</code></td>
+</tr>
+<tr>
+<td><code>docs/decisions/ADR-*.md</code></td>
+<td>Authored source</td>
+<td>Editar o MD e rodar <code>npm run sync:docs</code></td>
+</tr>
+<tr>
+<td><code>docs/decisions/adr-*.html</code></td>
+<td>Generated</td>
+<td>Não editar à mão</td>
+</tr>
+<tr>
+<td><code>docs/changelog.html</code></td>
+<td>Generated</td>
+<td>Editar <code>CHANGELOG.md</code></td>
+</tr>
+<tr>
+<td><code>docs/token-schema.md</code>, <code>docs/component-inventory.md</code>, <code>docs/adr-index.md</code></td>
+<td>Generated</td>
+<td>Rodar <code>npm run sync:docs</code></td>
+</tr>
+<tr>
+<td><code>docs/llms*.txt</code></td>
+<td>Generated</td>
+<td>Rodar <code>npm run build:llms</code></td>
+</tr>
+</tbody></table>
+<h2>Checklist de revisão</h2>
+<ul>
+<li>A página segue o template do tipo correto.</li>
+<li>Exceções estão declaradas.</li>
+<li>Tokens citados existem e passam em <code>npm run verify:tokens</code>.</li>
+<li>Labels de tabela usam a nomenclatura oficial deste guia.</li>
+<li>Mudança observável está registrada no <code>CHANGELOG.md</code>.</li>
+<li>Arquivos gerados foram atualizados pelo comando correto.</li>
+</ul>
+
+  </div>
+</main>
+
+<script src="../js/main.js"></script>
+</body>
+</html>

--- a/docs/documentation-guidelines.md
+++ b/docs/documentation-guidelines.md
@@ -1,0 +1,127 @@
+# Documentation guidelines
+
+Este guia define o contrato editorial das páginas do Design System Core. Use-o antes de criar, refatorar ou revisar páginas em `docs/`.
+
+## Princípios
+
+1. **Docs descrevem o estado atual.** A fonte de verdade continua sendo ADR, Figma, JSON e CSS conforme `AGENTS.md`.
+2. **Estrutura varia por finalidade.** Foundation, Component, Process e System pages não precisam ter o mesmo template.
+3. **Exceções devem ser explícitas.** Se uma página omite uma seção comum, explique o motivo na própria página ou neste guia.
+4. **Nomes oficiais não são inventados na documentação.** Use o nome do Figma, JSON ou CSS. Descrições de uso ficam em colunas de papel/uso.
+5. **Design System Core é o nome do projeto.** Enquanto não houver nome de produto final, não usar outro nome para o DS.
+
+## Tipos de página
+
+| Tipo | Finalidade | Exemplos |
+|---|---|---|
+| Foundation | Explicar escalas, tokens, valores e uso recomendado | Colors, Spacing, Elevation |
+| Component | Ensinar uso, anatomia, estados, tokens, CSS e acessibilidade | Button, Input, Tabs |
+| Process | Explicar fluxo operacional verificável | Contributing, Releasing, Versioning |
+| System | Explicar princípios, arquitetura e normas transversais | Token Architecture, Accessibility |
+
+## Foundation pages
+
+Template recomendado:
+
+1. Visão geral.
+2. Visual reference ou escala.
+3. Token reference.
+4. Uso e relações com outros sistemas, quando aplicável.
+5. Exceções arquiteturais, quando houver ADR.
+6. JSON (DTCG).
+
+Variações permitidas:
+
+- Colors e Theme Colors podem usar swatches em vez de tabelas.
+- Typography pode incluir preview de tipo.
+- Elevation deve mencionar surface, porque depth combina shadow e surface, especialmente em dark mode.
+- Motion, Z-index e Shadow/Elevation podem citar exceções CSS-only quando ligadas à ADR-016.
+
+## Component pages
+
+Template recomendado:
+
+1. Quando usar.
+2. Anatomia.
+3. Variantes, tamanhos, estados e exemplos.
+4. Boas práticas.
+5. Diretrizes de conteúdo, quando o componente renderiza texto, label ou mensagem.
+6. Mapeamento de tokens.
+7. Classes CSS.
+8. Propriedades Figma, quando houver variants/properties relevantes para handoff.
+9. Interação por teclado, quando interativo.
+10. Accessibility.
+11. Relacionados.
+
+Exceções permitidas:
+
+- Componentes não interativos não precisam de Interação por teclado.
+- Componentes simples podem ter uma anatomia curta, mas não devem omitir a intenção estrutural.
+- `Form Field` segue template próprio porque é CSS-only por ADR-017.
+
+## Form Field
+
+`Form Field` é CSS-only e não deve ser auditado como componente visual ausente no Figma. A página deve deixar claro que:
+
+- existe para compor markup HTML de label, control, helper e error;
+- não substitui os componentes Figma de Input, Select, Textarea, Checkbox, Radio ou Toggle;
+- mapeia comportamento de DOM e ARIA, não uma nova superfície visual no Figma.
+
+## Process pages
+
+Template recomendado:
+
+1. Escopo e fonte de verdade.
+2. Antes de começar.
+3. Passo a passo.
+4. Validação.
+5. Falhas comuns ou rollback.
+6. Links relacionados.
+
+## System pages
+
+Template recomendado:
+
+1. Princípio ou decisão.
+2. Impacto em design.
+3. Impacto em código.
+4. Tokens ou artefatos relacionados.
+5. Verificação.
+6. ADRs e processos relacionados.
+
+## Labels oficiais de tabelas
+
+Use estes labels em português:
+
+| Conceito | Label |
+|---|---|
+| CSS variable | Variável CSS |
+| Description | Descrição |
+| WCAG criterion | Critério WCAG |
+| Function / role | Função ou Papel |
+| Reference | Referência |
+| Class | Classe |
+| Property | Propriedade |
+| Value | Valor |
+| Usage | Uso |
+
+## Authored vs generated
+
+| Arquivo | Tipo | Como alterar |
+|---|---|---|
+| `docs/*.html` manuais | Authored | Editar o HTML direto |
+| `docs/*.md` publicados por `sync:docs` | Authored source | Editar o MD e rodar `npm run sync:docs` |
+| `docs/decisions/ADR-*.md` | Authored source | Editar o MD e rodar `npm run sync:docs` |
+| `docs/decisions/adr-*.html` | Generated | Não editar à mão |
+| `docs/changelog.html` | Generated | Editar `CHANGELOG.md` |
+| `docs/token-schema.md`, `docs/component-inventory.md`, `docs/adr-index.md` | Generated | Rodar `npm run sync:docs` |
+| `docs/llms*.txt` | Generated | Rodar `npm run build:llms` |
+
+## Checklist de revisão
+
+- A página segue o template do tipo correto.
+- Exceções estão declaradas.
+- Tokens citados existem e passam em `npm run verify:tokens`.
+- Labels de tabela usam a nomenclatura oficial deste guia.
+- Mudança observável está registrada no `CHANGELOG.md`.
+- Arquivos gerados foram atualizados pelo comando correto.

--- a/docs/form-field.html
+++ b/docs/form-field.html
@@ -53,6 +53,10 @@
       <div class="ds-callout__title"><span data-lang="pt">Não use Form Field quando</span><span data-lang="en">Don't use Form Field when</span></div>
       <span data-lang="pt">O controle não precisa de label visível (ex: search input no header com ícone, com <code>aria-label</code> direto no controle). Mesmo assim, considere usar Form Field com <code>--no-label</code> pra manter consistência de espaçamento.</span><span data-lang="en">The control doesn't need a visible label (e.g., search input in header with icon, using <code>aria-label</code> directly). Even so, consider Form Field with <code>--no-label</code> to keep spacing consistent.</span>
     </div>
+    <div class="ds-callout ds-callout--info">
+      <div class="ds-callout__title">CSS-only (ADR-017)</div>
+      <span data-lang="pt">Form Field não tem equivalente Figma dedicado. Ele existe para compor markup HTML/ARIA; Input, Select, Textarea, Checkbox, Radio e Toggle já carregam seus elementos de label/helper nas variants Figma.</span><span data-lang="en">Form Field has no dedicated Figma equivalent. It exists to compose HTML/ARIA markup; Input, Select, Textarea, Checkbox, Radio, and Toggle already include label/helper elements in their Figma variants.</span>
+    </div>
   </div>
 
   <!-- ANATOMY -->
@@ -212,6 +216,21 @@
     </div>
   </div>
 
+  <!-- BEST PRACTICES -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Boas práticas</span><span data-lang="en">Best practices</span></h2>
+    <div class="ds-dodont">
+      <div class="ds-dodont__item ds-dodont__item--do">
+        <div class="ds-dodont__label">Do</div>
+        <div class="ds-dodont__desc"><span data-lang="pt">Use <code>label[for]</code>, <code>id</code> e <code>aria-describedby</code> para conectar visual e semântica.</span><span data-lang="en">Use <code>label[for]</code>, <code>id</code>, and <code>aria-describedby</code> to connect visuals and semantics.</span></div>
+      </div>
+      <div class="ds-dodont__item ds-dodont__item--dont">
+        <div class="ds-dodont__label">Don't</div>
+        <div class="ds-dodont__desc"><span data-lang="pt">Não replique Form Field como componente Figma separado; isso duplicaria elementos já presentes nas variants dos controles.</span><span data-lang="en">Do not replicate Form Field as a separate Figma component; that would duplicate elements already present in control variants.</span></div>
+      </div>
+    </div>
+  </div>
+
   <!-- ACCESSIBILITY CHECKLIST -->
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Checklist de acessibilidade</span><span data-lang="en">Accessibility checklist</span></h2>
@@ -225,11 +244,27 @@
     </ul>
   </div>
 
+  <!-- TOKEN MAPPING -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
+    <table class="ds-token-table">
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <tbody>
+        <tr><td>gap</td><td><code>semantic.space.xs</code></td><td><code>--ds-space-xs</code></td></tr>
+        <tr><td>label color</td><td><code>semantic.content.strong</code></td><td><code>--ds-content-strong</code></td></tr>
+        <tr><td>helper color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>required/error color</td><td><code>semantic.feedback.error.content.default</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
+        <tr><td>label typography</td><td><code>semantic.body.*.sm</code></td><td><code>--ds-body-font-size-sm</code> / <code>--ds-body-line-height-sm</code></td></tr>
+        <tr><td>helper typography</td><td><code>semantic.body.*.xs</code></td><td><code>--ds-body-font-size-xs</code> / <code>--ds-body-line-height-md</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
   <!-- API REFERENCE -->
   <div class="ds-subsection">
-    <h2 class="ds-subsection__title"><span data-lang="pt">Classes</span><span data-lang="en">Classes</span></h2>
+    <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th>Class</th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-field</code></td><td><span data-lang="pt">Wrapper. Stack vertical com gap consistente.</span><span data-lang="en">Wrapper. Vertical stack with consistent gap.</span></td></tr>
         <tr><td><code>ds-field__label-row</code></td><td><span data-lang="pt">Linha do label + required (horizontal).</span><span data-lang="en">Label + required row (horizontal).</span></td></tr>
@@ -242,6 +277,19 @@
         <tr><td><code>ds-field--no-helper</code></td><td><span data-lang="pt">Modificador: esconde helper.</span><span data-lang="en">Modifier: hides helper.</span></td></tr>
       </tbody>
     </table>
+  </div>
+
+  <!-- RELATED -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Relacionados</span><span data-lang="en">Related</span></h2>
+    <div class="ds-related">
+      <a class="ds-related__link" href="input.html">Input</a>
+      <a class="ds-related__link" href="select.html">Select</a>
+      <a class="ds-related__link" href="textarea.html">Textarea</a>
+      <a class="ds-related__link" href="checkbox.html">Checkbox</a>
+      <a class="ds-related__link" href="radio.html">Radio</a>
+      <a class="ds-related__link" href="toggle.html">Toggle</a>
+    </div>
   </div>
 
 </main>

--- a/docs/foundations-borders.html
+++ b/docs/foundations-borders.html
@@ -76,7 +76,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Semantic Border Widths</span><span data-lang="en">Semantic Border Widths</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th>Token</th><th><span data-lang="pt">Referencia</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
+      <thead><tr><th>Token</th><th><span data-lang="pt">Referência</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
         <tr><td><code>--ds-border-width-subtle</code></td><td><code>border-width-1</code></td><td>1px</td><td><span data-lang="pt">Separadores sutis</span><span data-lang="en">Subtle separators</span></td></tr>
         <tr><td><code>--ds-border-width-default</code></td><td><code>border-width-1</code></td><td>1px</td><td><span data-lang="pt">Bordas padrão de componentes</span><span data-lang="en">Default component borders</span></td></tr>
@@ -95,7 +95,7 @@
 
     <h3 style="font-size:var(--ds-font-size-14);font-weight:var(--ds-font-weight-semibold);color:var(--ds-content-default);margin-bottom:var(--ds-dimension-12);"><span data-lang="pt">Bordas de controles de formulário</span><span data-lang="en">Form control borders</span></h3>
     <table class="ds-token-table">
-      <thead><tr><th>Token</th><th><span data-lang="pt">Referencia</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
+      <thead><tr><th>Token</th><th><span data-lang="pt">Referência</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
         <tr><td><code>--ds-border-control-default</code></td><td><code>feedback.error.border / neutral-500</code></td><td><span data-lang="pt">Borda padrão de controles de formulário (Input, Select, Textarea, Checkbox, Radio). Contraste ≥ 3:1 conforme WCAG 1.4.11.</span><span data-lang="en">Default border for form controls (Input, Select, Textarea, Checkbox, Radio). ≥ 3:1 contrast per WCAG 1.4.11.</span></td></tr>
         <tr><td><code>--ds-border-control-hover</code></td><td><code>neutral-600 (light) / neutral-400 (dark)</code></td><td><span data-lang="pt">Borda no hover de controles de formulário.</span><span data-lang="en">Border on hover for form controls.</span></td></tr>
@@ -105,7 +105,7 @@
 
     <h3 style="font-size:var(--ds-font-size-14);font-weight:var(--ds-font-weight-semibold);color:var(--ds-content-default);margin-bottom:var(--ds-dimension-12);"><span data-lang="pt">Bordas semânticas adicionais</span><span data-lang="en">Additional semantic borders</span></h3>
     <table class="ds-token-table">
-      <thead><tr><th>Token</th><th><span data-lang="pt">Referencia</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
+      <thead><tr><th>Token</th><th><span data-lang="pt">Referência</span><span data-lang="en">Reference</span></th><th><span data-lang="pt">Uso</span><span data-lang="en">Usage</span></th></tr></thead>
       <tbody>
         <tr><td><code>--ds-border-error</code></td><td><code>feedback.error.border</code></td><td><span data-lang="pt">Borda de validação de erro em campos de formulário.</span><span data-lang="en">Error validation border for form fields.</span></td></tr>
         <tr><td><code>--ds-border-brand</code></td><td><code>brand.default</code></td><td><span data-lang="pt">Borda de foco ou seleção em brand (alias de brand.default).</span><span data-lang="en">Focus or selection border in brand color (alias of brand.default).</span></td></tr>

--- a/docs/foundations-elevation.html
+++ b/docs/foundations-elevation.html
@@ -102,7 +102,7 @@
     <p style="color:var(--ds-content-default);margin-bottom:var(--ds-dimension-24);font-size:var(--ds-font-size-14);line-height:var(--ds-line-height-relaxed)"><span data-lang="pt">No modo dark, sombras são pouco visíveis em fundos escuros. A elevação e transmitida principalmente pela cor da superfície. A escala neutral fornece progressao natural de profundidade:</span><span data-lang="en">In dark mode, shadows are barely visible on dark backgrounds. Elevation is conveyed primarily through surface color. The neutral scale provides natural depth progression:</span></p>
     <table class="ds-props-table">
       <thead>
-        <tr><th>Token</th><th>Light</th><th>Dark</th><th><span data-lang="pt">Funcao</span><span data-lang="en">Role</span></th></tr>
+        <tr><th>Token</th><th>Light</th><th>Dark</th><th><span data-lang="pt">Função</span><span data-lang="en">Role</span></th></tr>
       </thead>
       <tbody>
         <tr><td><code>--ds-background-default</code></td><td>white</td><td>neutral-950</td><td><span data-lang="pt">Canvas da página (mais profundo)</span><span data-lang="en">Page canvas (deepest)</span></td></tr>

--- a/docs/foundations-motion.html
+++ b/docs/foundations-motion.html
@@ -161,7 +161,7 @@
 }</div>
 
     <p style="color:var(--ds-content-default);font-size:var(--ds-font-size-14);">
-      <span data-lang="pt">Referencia WCAG: <strong>2.3.3 Animation from Interactions (AAA)</strong>. Embora o DS tenha como alvo AA, isto e implementado porque o custo e quase zero e o impacto para usuários sensiveis a movimento e significativo.</span><span data-lang="en">WCAG reference: <strong>2.3.3 Animation from Interactions (AAA)</strong>. While the DS targets AA, this is implemented because the cost is near-zero and the impact for motion-sensitive users is significant.</span>
+      <span data-lang="pt">Referência WCAG: <strong>2.3.3 Animation from Interactions (AAA)</strong>. Embora o DS tenha como alvo AA, isto e implementado porque o custo e quase zero e o impacto para usuários sensiveis a movimento e significativo.</span><span data-lang="en">WCAG reference: <strong>2.3.3 Animation from Interactions (AAA)</strong>. While the DS targets AA, this is implemented because the cost is near-zero and the impact for motion-sensitive users is significant.</span>
     </p>
   </div>
 

--- a/docs/foundations-spacing.html
+++ b/docs/foundations-spacing.html
@@ -82,7 +82,7 @@
     <p style="color:var(--ds-content-default);margin-bottom:var(--ds-dimension-16)"><span data-lang="pt">Em 0.7.0 (2-layer) as escalas <code>inset</code>/<code>gap</code>/<code>component</code> foram consolidadas em uma única escala <code>space</code>. Cada token aliasa um valor Foundation.</span><span data-lang="en">In 0.7.0 (2-layer) the <code>inset</code>/<code>gap</code>/<code>component</code> scales were consolidated into a single <code>space</code> scale. Each token aliases a Foundation value.</span></p>
     <h3 style="margin:var(--ds-dimension-16) 0 var(--ds-dimension-8);color:var(--ds-content-default)"><span data-lang="pt">Escala única (padding, gap, margin entre componentes)</span><span data-lang="en">Single scale (padding, gap, margin between components)</span></h3>
     <table class="ds-semantic-table">
-      <thead><tr><th>Token</th><th><span data-lang="pt">Referencia Foundation</span><span data-lang="en">Foundation reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th></tr></thead>
+      <thead><tr><th>Token</th><th><span data-lang="pt">Referência Foundation</span><span data-lang="en">Foundation reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th></tr></thead>
       <tbody>
         <tr><td><code>--ds-space-2xs</code></td><td><code>spacing-2</code></td><td>2px</td></tr>
         <tr><td><code>--ds-space-xs</code></td><td><code>spacing-4</code></td><td>4px</td></tr>
@@ -95,7 +95,7 @@
     </table>
     <h3 style="margin:var(--ds-dimension-16) 0 var(--ds-dimension-8);color:var(--ds-content-default)"><span data-lang="pt">Seção (espaçamento entre seções/blocos grandes)</span><span data-lang="en">Section (spacing between sections/large blocks)</span></h3>
     <table class="ds-semantic-table">
-      <thead><tr><th>Token</th><th><span data-lang="pt">Referencia Foundation</span><span data-lang="en">Foundation reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th></tr></thead>
+      <thead><tr><th>Token</th><th><span data-lang="pt">Referência Foundation</span><span data-lang="en">Foundation reference</span></th><th><span data-lang="pt">Valor</span><span data-lang="en">Value</span></th></tr></thead>
       <tbody>
         <tr><td><code>--ds-space-section-sm</code></td><td><code>spacing-32</code></td><td>32px</td></tr>
         <tr><td><code>--ds-space-section-md</code></td><td><code>spacing-48</code></td><td>48px</td></tr>

--- a/docs/foundations-theme-colors.html
+++ b/docs/foundations-theme-colors.html
@@ -44,7 +44,7 @@
 <main class="ds-main">
   <div class="ds-section">
     <h1 class="ds-section__title"><span data-lang="pt">Theme Colors</span><span data-lang="en">Theme Colors</span></h1>
-    <p class="ds-section__subtitle"><span data-lang="pt">Tokens de cor semânticos que se adaptam ao modo light/dark. Referenciam primitivos foundation e fornecem significado consistente na interface. Alterne o modo escuro acima para ver os tokens mudarem.</span><span data-lang="en">Semantic color tokens that adapt to light/dark mode. These reference foundation primitives and provide consistent meaning across the UI. Toggle dark mode above to see tokens change.</span></p>
+    <p class="ds-section__subtitle"><span data-lang="pt">Tokens de cor semânticos que se adaptam ao modo light/dark. Referênciam primitivos foundation e fornecem significado consistente na interface. Alterne o modo escuro acima para ver os tokens mudarem.</span><span data-lang="en">Semantic color tokens that adapt to light/dark mode. These reference foundation primitives and provide consistent meaning across the UI. Toggle dark mode above to see tokens change.</span></p>
   </div>
 
   <!-- AUTO-GENERATED:THEME-COLORS:START — não edite à mão. Gerado por scripts/sync-docs.mjs a partir de tokens/semantic/{light,dark}.json -->

--- a/docs/input.html
+++ b/docs/input.html
@@ -530,8 +530,8 @@
         <tr><td>border-color (focus)</td><td><code>semantic.border.focus</code></td><td><code>--ds-border-focus</code></td></tr>
         <tr><td>border-color (error)</td><td><code>semantic.feedback.error.border-default</code></td><td><code>--ds-feedback-error-border-default</code></td></tr>
         <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-strong</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-subtle</code></td></tr>
-        <tr><td>icon color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-subtle</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.subtle</code></td><td><code>--ds-content-subtle</code></td></tr>
+        <tr><td>icon color</td><td><code>semantic.content.subtle</code></td><td><code>--ds-content-subtle</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-md</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>height (sm)</td><td><code>semantic.size.control.sm</code></td><td><code>--ds-size-lg</code> (32px)</td></tr>

--- a/docs/layout.css
+++ b/docs/layout.css
@@ -57,14 +57,18 @@ html[lang="en"] body [data-lang="pt"] { display: none; }
 .ds-site-header__logo {
   width: 32px;
   height: 32px;
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: var(--_hfg);
   border-radius: var(--ds-radius-8);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--_hfg);
+  color: var(--ds-primary-background-default);
   font-weight: var(--ds-font-weight-bold);
   font-size: var(--ds-font-size-14);
+}
+
+[data-mode="dark"] .ds-site-header__logo {
+  color: var(--ds-color-brand-900);
 }
 
 .ds-site-header__title {
@@ -450,13 +454,20 @@ html[lang="en"] body [data-lang="pt"] { display: none; }
 }
 
 .ds-preview__tab--active {
-  color: var(--ds-primary-background-default);
-  border-bottom-color: var(--ds-primary-background-default);
+  color: var(--ds-link-content-default);
+  border-bottom-color: var(--ds-link-content-default);
 }
 
 .ds-preview__tab:focus-visible {
   outline: var(--ds-border-width-focus) solid var(--ds-border-focus);
   outline-offset: var(--ds-border-width-focus);
+}
+
+/* Markdown-generated pages define this banner inline; keep text contrast
+   accessible from the shared docs stylesheet. */
+body .ds-md-generated-banner,
+body .ds-md-generated-banner code {
+  color: var(--ds-content-strong);
 }
 
 .ds-preview__panel {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -40,12 +40,13 @@ Depois serve o diretório estático (`python3 -m http.server` ou equivalente).
 
 ## Documentação completa
 
-Toda a documentação vive em **[uxindesign.github.io/design-system-core](https://uxindesign.github.io/design-system-core/)**. Lá estão: 19 componentes com preview ao vivo, 10 foundations, guias de tema e acessibilidade, 15 ADRs navegáveis, inventário de tokens, e consumo por IA em `/docs/llms.txt`.
+Toda a documentação vive em **[uxindesign.github.io/design-system-core](https://uxindesign.github.io/design-system-core/)**. Lá estão: 19 componentes com preview ao vivo, 10 foundations, guias de tema, acessibilidade e documentação, 18 ADRs navegáveis, inventário de tokens, e consumo por IA em `/docs/llms.txt`.
 
 Links rápidos:
 
 - [Getting Started](https://uxindesign.github.io/design-system-core/index.html)
 - [Token Architecture](https://uxindesign.github.io/design-system-core/docs/token-architecture.html)
+- [Documentation Guidelines](https://uxindesign.github.io/design-system-core/docs/documentation-guidelines.html)
 - [Component Inventory](./docs/component-inventory.md)
 - [Decisões (ADRs)](./docs/decisions/)
 - [Changelog](./CHANGELOG.md)
@@ -205,6 +206,7 @@ A partir de `1.0.0-beta.1`, o sistema entrou em **fase beta** — releases incre
 ## [Não publicado]
 
 ### Corrigido
+- **Documentação normalizada conforme auditoria estrutural.** Labels de tabela foram padronizados (`Variável CSS`, `Descrição`, `Critério WCAG`, `Função`, `Referência`), README atualizado para 18 ADRs, páginas simples de componentes ganharam anatomia curta, `Form Field` declara o contrato CSS-only na própria página, e referências stale a `semantic.content.secondary/tertiary` foram migradas para `semantic.content.default/subtle`.
 - **Escala de Elevation/Shadow oficializada em 4 níveis + reset.** Removidos `foundation.shadow.xs` e `foundation.shadow.2xl` por não terem uso nem Effect Style correspondente. `foundation.shadow.{sm,md,lg,xl}` preserva exatamente os parâmetros dos Effect Styles Figma `elevation/1..4`, e `foundation.shadow.none` permanece como reset técnico de `.ds-elevation-0`. A página de Elevation agora documenta o papel de cada nível e o mapping Figma ↔ CSS. Resolve #19 / P3-2 da auditoria Figma↔Repo.
 - **Documentação de Elevation mantém nomes oficiais numéricos.** A tabela de `foundations-elevation.html` agora mostra apenas os níveis `0` a `4` como nomes oficiais, sem rótulos descritivos não existentes no Figma/JSON.
 - **Documentação de Elevation separa conceito de utility CSS.** A tabela principal agora segue o padrão de Foundation (`Nível`, Figma, sombra, surface recomendada e papel), enquanto `.ds-elevation-*` fica documentado como utility auxiliar que aplica apenas `box-shadow`.
@@ -245,6 +247,7 @@ A partir de `1.0.0-beta.1`, o sistema entrou em **fase beta** — releases incre
 
 ### Adicionado
 
+- **Guia editorial de documentação** (`docs/documentation-guidelines.md`). Define templates para páginas Foundation, Component, Process e System, exceções permitidas, labels oficiais de tabela e regra authored vs generated.
 - **Auditoria estrutural da documentação** (`audit/docs-structure-audit.md`). Classifica páginas por tipo (Foundation, Component, Process, System), identifica inconsistências editoriais e define uma sequência recomendada de PRs para normalização.
 
 - **ADR-018 — Renomear `content.{default,secondary,tertiary}` para `content.{strong,default,subtle}`.** Único conjunto de tokens do DS com naming ordinal foi alinhado ao vocabulário descritivo das demais categorias (`border.{strong,default,subtle}`, `surface.*`, `background.*`). Strict rename — valores 100% preservados, só nomes mudaram. Migração: keys em `tokens/semantic/{light,dark}.json`, entries em `tokens/registry.json`, `--ds-content-*` em CSS de componente/base e em HTMLs/MDs de docs (sed-replace via 3 passos com placeholder pra evitar clash), Variables `content/{default,secondary,tertiary}` na collection Semantic do Figma via `use_figma` (bindings auto-seguem por ID). `npm run build:tokens` + `build:api` + `sync:docs` regeneram derivados. Decisão tomada durante #4 P1-1 da auditoria Figma↔Repo, quando `content/secondary` apareceu como text token do Badge Neutral Subtle.
@@ -1513,6 +1516,139 @@ A marca se compromete com WCAG 2.2 AA como mínimo. Isso implica:
 2. **prefers-reduced-motion** — media query nos componentes com transitions (ADR-004 pendente)
 3. **CSS legado** — verificar/remover `css/tokens/theme-light.css` (ADR-010 pendente)
 4. **Novos componentes** — Dropdown, Combobox, Pagination, Table
+
+
+═══════════════════════════════════════════════════════════
+# docs/documentation-guidelines.md
+═══════════════════════════════════════════════════════════
+
+# Documentation guidelines
+
+Este guia define o contrato editorial das páginas do Design System Core. Use-o antes de criar, refatorar ou revisar páginas em `docs/`.
+
+## Princípios
+
+1. **Docs descrevem o estado atual.** A fonte de verdade continua sendo ADR, Figma, JSON e CSS conforme `AGENTS.md`.
+2. **Estrutura varia por finalidade.** Foundation, Component, Process e System pages não precisam ter o mesmo template.
+3. **Exceções devem ser explícitas.** Se uma página omite uma seção comum, explique o motivo na própria página ou neste guia.
+4. **Nomes oficiais não são inventados na documentação.** Use o nome do Figma, JSON ou CSS. Descrições de uso ficam em colunas de papel/uso.
+5. **Design System Core é o nome do projeto.** Enquanto não houver nome de produto final, não usar outro nome para o DS.
+
+## Tipos de página
+
+| Tipo | Finalidade | Exemplos |
+|---|---|---|
+| Foundation | Explicar escalas, tokens, valores e uso recomendado | Colors, Spacing, Elevation |
+| Component | Ensinar uso, anatomia, estados, tokens, CSS e acessibilidade | Button, Input, Tabs |
+| Process | Explicar fluxo operacional verificável | Contributing, Releasing, Versioning |
+| System | Explicar princípios, arquitetura e normas transversais | Token Architecture, Accessibility |
+
+## Foundation pages
+
+Template recomendado:
+
+1. Visão geral.
+2. Visual reference ou escala.
+3. Token reference.
+4. Uso e relações com outros sistemas, quando aplicável.
+5. Exceções arquiteturais, quando houver ADR.
+6. JSON (DTCG).
+
+Variações permitidas:
+
+- Colors e Theme Colors podem usar swatches em vez de tabelas.
+- Typography pode incluir preview de tipo.
+- Elevation deve mencionar surface, porque depth combina shadow e surface, especialmente em dark mode.
+- Motion, Z-index e Shadow/Elevation podem citar exceções CSS-only quando ligadas à ADR-016.
+
+## Component pages
+
+Template recomendado:
+
+1. Quando usar.
+2. Anatomia.
+3. Variantes, tamanhos, estados e exemplos.
+4. Boas práticas.
+5. Diretrizes de conteúdo, quando o componente renderiza texto, label ou mensagem.
+6. Mapeamento de tokens.
+7. Classes CSS.
+8. Propriedades Figma, quando houver variants/properties relevantes para handoff.
+9. Interação por teclado, quando interativo.
+10. Accessibility.
+11. Relacionados.
+
+Exceções permitidas:
+
+- Componentes não interativos não precisam de Interação por teclado.
+- Componentes simples podem ter uma anatomia curta, mas não devem omitir a intenção estrutural.
+- `Form Field` segue template próprio porque é CSS-only por ADR-017.
+
+## Form Field
+
+`Form Field` é CSS-only e não deve ser auditado como componente visual ausente no Figma. A página deve deixar claro que:
+
+- existe para compor markup HTML de label, control, helper e error;
+- não substitui os componentes Figma de Input, Select, Textarea, Checkbox, Radio ou Toggle;
+- mapeia comportamento de DOM e ARIA, não uma nova superfície visual no Figma.
+
+## Process pages
+
+Template recomendado:
+
+1. Escopo e fonte de verdade.
+2. Antes de começar.
+3. Passo a passo.
+4. Validação.
+5. Falhas comuns ou rollback.
+6. Links relacionados.
+
+## System pages
+
+Template recomendado:
+
+1. Princípio ou decisão.
+2. Impacto em design.
+3. Impacto em código.
+4. Tokens ou artefatos relacionados.
+5. Verificação.
+6. ADRs e processos relacionados.
+
+## Labels oficiais de tabelas
+
+Use estes labels em português:
+
+| Conceito | Label |
+|---|---|
+| CSS variable | Variável CSS |
+| Description | Descrição |
+| WCAG criterion | Critério WCAG |
+| Function / role | Função ou Papel |
+| Reference | Referência |
+| Class | Classe |
+| Property | Propriedade |
+| Value | Valor |
+| Usage | Uso |
+
+## Authored vs generated
+
+| Arquivo | Tipo | Como alterar |
+|---|---|---|
+| `docs/*.html` manuais | Authored | Editar o HTML direto |
+| `docs/*.md` publicados por `sync:docs` | Authored source | Editar o MD e rodar `npm run sync:docs` |
+| `docs/decisions/ADR-*.md` | Authored source | Editar o MD e rodar `npm run sync:docs` |
+| `docs/decisions/adr-*.html` | Generated | Não editar à mão |
+| `docs/changelog.html` | Generated | Editar `CHANGELOG.md` |
+| `docs/token-schema.md`, `docs/component-inventory.md`, `docs/adr-index.md` | Generated | Rodar `npm run sync:docs` |
+| `docs/llms*.txt` | Generated | Rodar `npm run build:llms` |
+
+## Checklist de revisão
+
+- A página segue o template do tipo correto.
+- Exceções estão declaradas.
+- Tokens citados existem e passam em `npm run verify:tokens`.
+- Labels de tabela usam a nomenclatura oficial deste guia.
+- Mudança observável está registrada no `CHANGELOG.md`.
+- Arquivos gerados foram atualizados pelo comando correto.
 
 
 ═══════════════════════════════════════════════════════════

--- a/docs/modal.html
+++ b/docs/modal.html
@@ -354,7 +354,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td>overlay background</td><td><code>semantic.background.overlay</code></td><td><code>--ds-background-overlay</code></td></tr>
         <tr><td>surface</td><td><code>semantic.surface.elevated</code></td><td><code>--ds-surface-elevated</code></td></tr>
@@ -373,7 +373,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-modal-overlay</code></td><td><span data-lang="pt">Overlay backdrop em tela cheia</span><span data-lang="en">Full-screen backdrop overlay</span></td></tr>
         <tr><td><code>ds-modal</code></td><td><span data-lang="pt">Container do diálogo modal</span><span data-lang="en">Modal dialog container</span></td></tr>
@@ -414,7 +414,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>2.4.3 Focus Order (A)</td><td><span data-lang="pt">O foco move para dentro do modal ao abrir, fica preso dentro e retorna ao trigger ao fechar</span><span data-lang="en">Focus moves into the modal on open, is trapped inside, and returns to the trigger on close</span></td><td>&#10003;</td></tr>
         <tr><td>2.4.11 Focus Appearance (AA)</td><td><span data-lang="pt">Focus ring visível em todos os elementos interativos dentro do modal</span><span data-lang="en">Focus ring visible on all interactive elements inside the modal</span></td><td>&#10003;</td></tr>

--- a/docs/select.html
+++ b/docs/select.html
@@ -465,7 +465,7 @@
         <tr><td>border (hover)</td><td><code>semantic.border.control-hover</code></td><td><code>--ds-border-control-hover</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.bg-default</code></td><td><code>--ds-feedback-error-background-default</code></td></tr>
         <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-strong</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-subtle</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.subtle</code></td><td><code>--ds-content-subtle</code></td></tr>
         <tr><td>arrow color</td><td>Inherits via <code>currentColor</code></td><td>---</td></tr>
         <tr><td>background (disabled)</td><td><code>semantic.background.disabled</code></td><td><code>--ds-background-disabled</code></td></tr>
         <tr><td>text (disabled)</td><td><code>semantic.content.disabled</code></td><td><code>--ds-content-disabled</code></td></tr>

--- a/docs/skeleton.html
+++ b/docs/skeleton.html
@@ -60,7 +60,22 @@
   </div>
 
   <!-- ============================================================
-       3. VARIANTS (live previews)
+       3. ANATOMY
+       ============================================================ -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Anatomia</span><span data-lang="en">Anatomy</span></h2>
+    <div class="ds-anatomy-legend">
+      <span data-lang="pt"><strong>1</strong> Shape (<code>.ds-skeleton</code>) — bloco visual sem conteúdo semântico próprio.<br>
+      <strong>2</strong> Variante de forma — text, circle ou rectangle.<br>
+      <strong>3</strong> Container de loading — aplica <code>aria-busy="true"</code> no conteúdo que está sendo carregado; shapes individuais podem usar <code>aria-hidden="true"</code>.</span>
+      <span data-lang="en"><strong>1</strong> Shape (<code>.ds-skeleton</code>) — visual block with no semantic content of its own.<br>
+      <strong>2</strong> Shape variant — text, circle, or rectangle.<br>
+      <strong>3</strong> Loading container — apply <code>aria-busy="true"</code> to the content being loaded; individual shapes can use <code>aria-hidden="true"</code>.</span>
+    </div>
+  </div>
+
+  <!-- ============================================================
+       4. VARIANTS (live previews)
        ============================================================ -->
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Skeleton de texto</span><span data-lang="en">Text skeleton</span></h2>
@@ -267,7 +282,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">fundo</span><span data-lang="en">background</span></td><td><code>semantic.background.disabled</code></td><td><code>--ds-background-disabled</code></td></tr>
         <tr><td><span data-lang="pt">animação (pulso de opacidade)</span><span data-lang="en">animation (opacity pulse)</span></td><td><span data-lang="pt">valores literais (sem token)</span><span data-lang="en">literal values (no token)</span></td><td><span data-lang="pt"><code>opacity: 1</code> → <code>0.4</code> → <code>1</code> (keyframe @ds-pulse)</span><span data-lang="en"><code>opacity: 1</code> → <code>0.4</code> → <code>1</code> (keyframe @ds-pulse)</span></td></tr>
@@ -283,7 +298,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-skeleton</code></td><td><span data-lang="pt">Classe base do skeleton com animação de pulso</span><span data-lang="en">Base skeleton class with pulse animation</span></td></tr>
         <tr><td><code>ds-skeleton--text</code></td><td><span data-lang="pt">Placeholder de linha de texto (border-radius pequeno)</span><span data-lang="en">Text line placeholder (small border-radius)</span></td></tr>
@@ -299,7 +314,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>4.1.2 Name, Role, Value (A)</td><td><span data-lang="pt"><code>aria-busy="true"</code> no container de carregamento + <code>aria-label</code> descrevendo o que esta carregando</span><span data-lang="en"><code>aria-busy="true"</code> on the loading container + <code>aria-label</code> describing what is loading</span></td><td>&#10003;</td></tr>
         <tr><td>1.3.1 Info and Relationships (A)</td><td><span data-lang="pt"><code>aria-hidden="true"</code> em elementos skeleton individuais (são decorativos)</span><span data-lang="en"><code>aria-hidden="true"</code> on individual skeleton elements (they are decorative)</span></td><td>&#10003;</td></tr>

--- a/docs/spinner.html
+++ b/docs/spinner.html
@@ -60,7 +60,22 @@
   </div>
 
   <!-- ============================================================
-       3. VARIANTS (live previews)
+       3. ANATOMY
+       ============================================================ -->
+  <div class="ds-subsection">
+    <h2 class="ds-subsection__title"><span data-lang="pt">Anatomia</span><span data-lang="en">Anatomy</span></h2>
+    <div class="ds-anatomy-legend">
+      <span data-lang="pt"><strong>1</strong> Container (<code>.ds-spinner</code>) — elemento inline flex com tamanho tokenizado.<br>
+      <strong>2</strong> Ring — borda circular animada por rotação linear.<br>
+      <strong>3</strong> Size/style modifiers — <code>--sm</code>, <code>--md</code>, <code>--lg</code> e <code>--on-color</code>.</span>
+      <span data-lang="en"><strong>1</strong> Container (<code>.ds-spinner</code>) — inline-flex element with tokenized size.<br>
+      <strong>2</strong> Ring — circular border animated with linear rotation.<br>
+      <strong>3</strong> Size/style modifiers — <code>--sm</code>, <code>--md</code>, <code>--lg</code>, and <code>--on-color</code>.</span>
+    </div>
+  </div>
+
+  <!-- ============================================================
+       4. VARIANTS (live previews)
        ============================================================ -->
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Tamanhos</span><span data-lang="en">Sizes</span></h2>
@@ -218,7 +233,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">indicador default</span><span data-lang="en">default indicator</span></td><td><code>semantic.border.brand</code></td><td><code>--ds-border-brand</code></td></tr>
         <tr><td><span data-lang="pt">trilha default</span><span data-lang="en">default track</span></td><td><code>semantic.border.subtle</code></td><td><code>--ds-border-subtle</code></td></tr>
@@ -237,7 +252,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-spinner</code></td><td><span data-lang="pt">Classe base do spinner</span><span data-lang="en">Base spinner class</span></td></tr>
         <tr><td><code>ds-spinner--sm</code></td><td><span data-lang="pt">Tamanho pequeno (<code>--ds-size-xs</code>)</span><span data-lang="en">Small size (<code>--ds-size-xs</code>)</span></td></tr>
@@ -254,7 +269,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>4.1.2 Name, Role, Value (A)</td><td><span data-lang="pt"><code>role="status"</code> + <code>aria-label="Loading"</code> em cada spinner</span><span data-lang="en"><code>role="status"</code> + <code>aria-label="Loading"</code> on every spinner</span></td><td>&#10003;</td></tr>
         <tr><td>2.3.1 Three Flashes (A)</td><td><span data-lang="pt">A animação e uma rotacao continua, não piscante</span><span data-lang="en">Animation is a continuous rotation, not flashing</span></td><td>&#10003;</td></tr>

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -251,7 +251,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Mapeamento de tokens</span><span data-lang="en">Token mapping</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variavel CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Propriedade</span><span data-lang="en">Property</span></th><th>Token (semantic)</th><th><span data-lang="pt">Variável CSS</span><span data-lang="en">CSS variable</span></th></tr></thead>
       <tbody>
         <tr><td><span data-lang="pt">texto (inativo)</span><span data-lang="en">text (inactive)</span></td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
         <tr><td><span data-lang="pt">texto (hover)</span><span data-lang="en">text (hover)</span></td><td><code>semantic.content.strong</code></td><td><code>--ds-content-strong</code></td></tr>
@@ -271,7 +271,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Classes CSS</span><span data-lang="en">CSS classes</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descricao</span><span data-lang="en">Description</span></th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Classe</span><span data-lang="en">Class</span></th><th><span data-lang="pt">Descrição</span><span data-lang="en">Description</span></th></tr></thead>
       <tbody>
         <tr><td><code>ds-tabs</code></td><td><span data-lang="pt">Container da lista de tabs</span><span data-lang="en">Tab list container</span></td></tr>
         <tr><td><code>ds-tab</code></td><td><span data-lang="pt">Button individual de tab</span><span data-lang="en">Individual tab button</span></td></tr>
@@ -308,7 +308,7 @@
   <div class="ds-subsection">
     <h2 class="ds-subsection__title"><span data-lang="pt">Accessibility</span><span data-lang="en">Accessibility</span></h2>
     <table class="ds-token-table">
-      <thead><tr><th><span data-lang="pt">Criterio WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
+      <thead><tr><th><span data-lang="pt">Critério WCAG</span><span data-lang="en">WCAG criterion</span></th><th><span data-lang="pt">Requisito</span><span data-lang="en">Requirement</span></th><th>Status</th></tr></thead>
       <tbody>
         <tr><td>4.1.2 Name, Role, Value (A)</td><td><span data-lang="pt"><code>role="tablist"</code>, <code>role="tab"</code>, <code>role="tabpanel"</code>. <code>aria-selected</code> nas tabs. <code>aria-controls</code> / <code>aria-labelledby</code> vinculando tabs a paineis.</span><span data-lang="en"><code>role="tablist"</code>, <code>role="tab"</code>, <code>role="tabpanel"</code>. <code>aria-selected</code> on tabs. <code>aria-controls</code> / <code>aria-labelledby</code> linking tabs to panels.</span></td><td>&#10003;</td></tr>
         <tr><td>2.1.1 Keyboard (A)</td><td><span data-lang="pt">Setas navegam entre tabs. <code>Tab</code> entra e sai da lista de tabs.</span><span data-lang="en">Arrow keys navigate between tabs. <code>Tab</code> enters and exits the tab list.</span></td><td>&#10003;</td></tr>

--- a/docs/textarea.html
+++ b/docs/textarea.html
@@ -387,7 +387,7 @@
         <tr><td>border (focus)</td><td><code>semantic.primary.background.default</code></td><td><code>--ds-primary-background-default</code></td></tr>
         <tr><td>border (error)</td><td><code>semantic.feedback.error.bg-default</code></td><td><code>--ds-feedback-error-background-default</code></td></tr>
         <tr><td>text color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-strong</code></td></tr>
-        <tr><td>placeholder color</td><td><code>semantic.content.tertiary</code></td><td><code>--ds-content-subtle</code></td></tr>
+        <tr><td>placeholder color</td><td><code>semantic.content.subtle</code></td><td><code>--ds-content-subtle</code></td></tr>
         <tr><td>border-radius</td><td><code>semantic.radius.component</code></td><td><code>--ds-radius-md</code></td></tr>
         <tr><td>focus ring</td><td><code>semantic.focus.ring.*</code></td><td><code>--ds-focus-ring-width</code>, <code>--ds-focus-ring-offset</code>, <code>--ds-focus-ring-color</code></td></tr>
         <tr><td>padding-x (sm/md/lg)</td><td><code>semantic.space.control.padding-x.*</code></td><td><code>--ds-space-md/md/lg</code></td></tr>
@@ -400,7 +400,7 @@
         <tr><td>min-height (sm)</td><td>--</td><td><code>80px</code></td></tr>
         <tr><td>min-height (md)</td><td>--</td><td><code>120px</code></td></tr>
         <tr><td>min-height (lg)</td><td>--</td><td><code>160px</code></td></tr>
-        <tr><td>counter color</td><td><code>semantic.content.secondary</code></td><td><code>--ds-content-default</code></td></tr>
+        <tr><td>counter color</td><td><code>semantic.content.default</code></td><td><code>--ds-content-default</code></td></tr>
         <tr><td>counter color (over)</td><td><code>semantic.feedback.error.content-default</code></td><td><code>--ds-feedback-error-content-default</code></td></tr>
       </tbody>
     </table>

--- a/docs/token-architecture.html
+++ b/docs/token-architecture.html
@@ -131,7 +131,7 @@
       <article class="ds-layer">
         <h3 class="ds-layer__title"><span class="ds-layer__title-num">02</span>Semantic</h3>
         <p class="ds-layer__count"><span data-lang="pt">171 tokens × 2 modos · publicada pra Figma</span><span data-lang="en">171 tokens × 2 modes · published to Figma</span></p>
-        <p class="ds-layer__role"><span data-lang="pt">Intenção e significado, com naming t-shirt (sm/md/lg). Referencia Foundation via aliases. Light e dark sobrescrevem só esta camada.</span><span data-lang="en">Intent and meaning, with t-shirt naming (sm/md/lg). References Foundation via aliases. Light and dark only override this layer.</span></p>
+        <p class="ds-layer__role"><span data-lang="pt">Intenção e significado, com naming t-shirt (sm/md/lg). Referência Foundation via aliases. Light e dark sobrescrevem só esta camada.</span><span data-lang="en">Intent and meaning, with t-shirt naming (sm/md/lg). References Foundation via aliases. Light and dark only override this layer.</span></p>
         <div class="ds-layer__entries">
           <div class="ds-layer__entry"><code>primary.background.default</code><span>→</span><code>{color.blue.600}</code></div>
           <div class="ds-layer__entry"><code>content.default</code><span>→</span><code>{color.neutral.900}</code><span class="ds-layer__entry-mode">light</span></div>

--- a/js/main.js
+++ b/js/main.js
@@ -68,7 +68,8 @@
       items: [
         { label: 'Theming',        path: 'docs/theming.html' },
         { label: 'Accessibility',  path: 'docs/accessibility.html' },
-        { label: 'Control Sizing', path: 'docs/control-sizing.html' }
+        { label: 'Control Sizing', path: 'docs/control-sizing.html' },
+        { label: 'Documentation',  path: 'docs/documentation-guidelines.html' }
       ]
     },
     {

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -431,6 +431,7 @@ const mdPages = [
   { src: 'CHANGELOG.md', out: 'docs/changelog.html', title: 'Changelog', subtitle: 'Histórico de versões do design system.' },
   { src: 'docs/brand-principles.md', out: 'docs/brand-principles.html', title: 'Princípios da marca', subtitle: 'Missão, princípios, tom de voz e identidade visual.' },
   { src: 'docs/backlog.md', out: 'docs/backlog.html', title: 'Backlog', subtitle: 'Itens fora do escopo imediato mas que devem ser implementados.' },
+  { src: 'docs/documentation-guidelines.md', out: 'docs/documentation-guidelines.html', title: 'Documentation guidelines', subtitle: 'Templates editoriais para páginas de Foundation, Component, Process e System.' },
   { src: 'docs/process-contributing.md', out: 'docs/process-contributing.html', title: 'Como contribuir', subtitle: 'Setup local, fluxo de PR, convenções de commit.' },
   { src: 'docs/process-versioning.md', out: 'docs/process-versioning.html', title: 'Versionamento', subtitle: 'Regras de bump de versão no design system.' },
   { src: 'docs/process-releasing.md', out: 'docs/process-releasing.html', title: 'Releases', subtitle: 'Passo a passo de uma release.' },


### PR DESCRIPTION
## Resumo
- cria guia editorial de documentação e publica na navegação
- normaliza labels e entrypoints da documentação sem alterar Brand Principles
- explicita exceções de componentes simples e Form Field CSS-only
- ajusta contraste do shell de docs sem actualizar baseline de a11y

## Verificação
- npm run sync:docs
- npm run build:llms
- npm run verify:tokens
- npm test