### PR TITLE
fix(templates): corrigir layout, validação, branding e responsividade

### DIFF
--- a/docs/template-dashboard.html
+++ b/docs/template-dashboard.html
@@ -44,8 +44,8 @@
   </div>
 
   <div class="ds-subsection">
-    <div style="display:flex;align-items:center;gap:var(--ds-space-md);margin-bottom:var(--ds-space-lg)">
-      <h2 class="ds-subsection__title" style="margin-bottom:0"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
+    <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:var(--ds-border-width-1) solid var(--ds-border-default);padding-bottom:var(--ds-dimension-8);margin-bottom:var(--ds-dimension-16)">
+      <h2 style="font-size:var(--ds-font-size-20);font-weight:var(--ds-font-weight-semibold)"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
       <a href="../templates/dashboard.html" target="_blank" rel="noopener" class="ds-btn ds-btn--outline ds-btn--sm">
         <span data-lang="pt">Abrir em tela cheia</span><span data-lang="en">Open fullscreen</span>
       </a>

--- a/docs/template-landing.html
+++ b/docs/template-landing.html
@@ -44,8 +44,8 @@
   </div>
 
   <div class="ds-subsection">
-    <div style="display:flex;align-items:center;gap:var(--ds-space-md);margin-bottom:var(--ds-space-lg)">
-      <h2 class="ds-subsection__title" style="margin-bottom:0"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
+    <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:var(--ds-border-width-1) solid var(--ds-border-default);padding-bottom:var(--ds-dimension-8);margin-bottom:var(--ds-dimension-16)">
+      <h2 style="font-size:var(--ds-font-size-20);font-weight:var(--ds-font-weight-semibold)"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
       <a href="../templates/landing.html" target="_blank" rel="noopener" class="ds-btn ds-btn--outline ds-btn--sm">
         <span data-lang="pt">Abrir em tela cheia</span><span data-lang="en">Open fullscreen</span>
       </a>

--- a/docs/template-login.html
+++ b/docs/template-login.html
@@ -44,8 +44,8 @@
   </div>
 
   <div class="ds-subsection">
-    <div style="display:flex;align-items:center;gap:var(--ds-space-md);margin-bottom:var(--ds-space-lg)">
-      <h2 class="ds-subsection__title" style="margin-bottom:0"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
+    <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:var(--ds-border-width-1) solid var(--ds-border-default);padding-bottom:var(--ds-dimension-8);margin-bottom:var(--ds-dimension-16)">
+      <h2 style="font-size:var(--ds-font-size-20);font-weight:var(--ds-font-weight-semibold)"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
       <a href="../templates/login.html" target="_blank" rel="noopener" class="ds-btn ds-btn--outline ds-btn--sm">
         <span data-lang="pt">Abrir em tela cheia</span><span data-lang="en">Open fullscreen</span>
       </a>

--- a/docs/template-signup.html
+++ b/docs/template-signup.html
@@ -44,8 +44,8 @@
   </div>
 
   <div class="ds-subsection">
-    <div style="display:flex;align-items:center;gap:var(--ds-space-md);margin-bottom:var(--ds-space-lg)">
-      <h2 class="ds-subsection__title" style="margin-bottom:0"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
+    <div style="display:flex;align-items:center;justify-content:space-between;border-bottom:var(--ds-border-width-1) solid var(--ds-border-default);padding-bottom:var(--ds-dimension-8);margin-bottom:var(--ds-dimension-16)">
+      <h2 style="font-size:var(--ds-font-size-20);font-weight:var(--ds-font-weight-semibold)"><span data-lang="pt">Visualização</span><span data-lang="en">Preview</span></h2>
       <a href="../templates/signup.html" target="_blank" rel="noopener" class="ds-btn ds-btn--outline ds-btn--sm">
         <span data-lang="pt">Abrir em tela cheia</span><span data-lang="en">Open fullscreen</span>
       </a>

--- a/docs/templates.html
+++ b/docs/templates.html
@@ -61,28 +61,28 @@
     <h2 class="ds-subsection__title"><span data-lang="pt">Templates disponíveis</span><span data-lang="en">Available templates</span></h2>
     <div class="ds-component-grid">
 
-      <a href="template-login.html" class="ds-component-card">
+      <a href="template-login.html" class="ds-component-card" style="flex-direction:column;align-items:flex-start;gap:var(--ds-space-sm)">
         <span class="ds-badge ds-badge--info ds-badge--subtle">Auth</span>
-        <div class="ds-component-card__name"><span data-lang="pt">Página de Login</span><span data-lang="en">Login Page</span></div>
-        <div class="ds-component-card__desc"><span data-lang="pt">Card centralizado com formulário de autenticação</span><span data-lang="en">Centered card with authentication form</span></div>
+        <strong><span data-lang="pt">Página de Login</span><span data-lang="en">Login Page</span></strong>
+        <span class="ds-text-body-sm" style="color:var(--ds-content-subtle)"><span data-lang="pt">Card centralizado com formulário de autenticação</span><span data-lang="en">Centered card with authentication form</span></span>
       </a>
 
-      <a href="template-signup.html" class="ds-component-card">
+      <a href="template-signup.html" class="ds-component-card" style="flex-direction:column;align-items:flex-start;gap:var(--ds-space-sm)">
         <span class="ds-badge ds-badge--info ds-badge--subtle">Auth</span>
-        <div class="ds-component-card__name"><span data-lang="pt">Página de Cadastro</span><span data-lang="en">Signup Page</span></div>
-        <div class="ds-component-card__desc"><span data-lang="pt">Layout split com formulário em grid e painel de marca</span><span data-lang="en">Split layout with grid form and brand panel</span></div>
+        <strong><span data-lang="pt">Página de Cadastro</span><span data-lang="en">Signup Page</span></strong>
+        <span class="ds-text-body-sm" style="color:var(--ds-content-subtle)"><span data-lang="pt">Layout split com formulário em grid e painel de marca</span><span data-lang="en">Split layout with grid form and brand panel</span></span>
       </a>
 
-      <a href="template-dashboard.html" class="ds-component-card">
+      <a href="template-dashboard.html" class="ds-component-card" style="flex-direction:column;align-items:flex-start;gap:var(--ds-space-sm)">
         <span class="ds-badge ds-badge--primary ds-badge--subtle">App</span>
-        <div class="ds-component-card__name">Dashboard</div>
-        <div class="ds-component-card__desc"><span data-lang="pt">Interface interna com sidebar, topbar, stat cards e tabela</span><span data-lang="en">Internal interface with sidebar, topbar, stat cards, and table</span></div>
+        <strong>Dashboard</strong>
+        <span class="ds-text-body-sm" style="color:var(--ds-content-subtle)"><span data-lang="pt">Interface interna com sidebar, topbar, stat cards e tabela</span><span data-lang="en">Internal interface with sidebar, topbar, stat cards, and table</span></span>
       </a>
 
-      <a href="template-landing.html" class="ds-component-card">
+      <a href="template-landing.html" class="ds-component-card" style="flex-direction:column;align-items:flex-start;gap:var(--ds-space-sm)">
         <span class="ds-badge ds-badge--success ds-badge--subtle">Marketing</span>
-        <div class="ds-component-card__name">Landing Page</div>
-        <div class="ds-component-card__desc"><span data-lang="pt">Página institucional com hero, features, preços e CTA</span><span data-lang="en">Institutional page with hero, features, pricing, and CTA</span></div>
+        <strong>Landing Page</strong>
+        <span class="ds-text-body-sm" style="color:var(--ds-content-subtle)"><span data-lang="pt">Página institucional com hero, features, preços e CTA</span><span data-lang="en">Institutional page with hero, features, pricing, and CTA</span></span>
       </a>
 
     </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,13 +12,12 @@
     })();
   </script>
   <style>
-    /* Estrutura de página — usa exclusivamente tokens DS */
     .tpl-login-page {
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--ds-background-subtle);
+      background: var(--ds-surface-default);
       padding: var(--ds-space-section-sm);
     }
     .tpl-login-box {
@@ -26,13 +25,7 @@
       max-width: var(--ds-size-layout-xs);
       display: flex;
       flex-direction: column;
-      gap: var(--ds-space-2xl);
-    }
-    .tpl-login-brand {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: var(--ds-space-sm);
+      gap: var(--ds-space-xl);
     }
     .tpl-login-form {
       display: flex;
@@ -49,22 +42,16 @@
 <main class="tpl-login-page" id="main-content">
   <div class="tpl-login-box">
 
-    <!-- Marca -->
-    <div class="tpl-login-brand">
-      <div class="ds-site-header__logo" aria-hidden="true">DS</div>
-      <p class="ds-text-body-sm" style="color:var(--ds-content-subtle)">Design System</p>
-    </div>
-
     <!-- Card de login -->
-    <div class="ds-card ds-card--outlined" role="region" aria-labelledby="login-title">
+    <div class="ds-card ds-card--elevated" role="region" aria-labelledby="login-title">
       <div class="ds-card__header">
-        <h1 class="ds-card__title ds-text-heading-md" id="login-title">Bem-vindo de volta</h1>
-        <p class="ds-card__subtitle ds-text-body-sm">Acesse sua conta para continuar</p>
+        <h1 class="ds-card__title ds-text-heading-lg" id="login-title">Entrar</h1>
+        <p class="ds-card__subtitle ds-text-body-md">Acesse sua conta para continuar</p>
       </div>
       <div class="ds-card__body">
-        <form class="tpl-login-form" novalidate>
+        <form class="tpl-login-form" novalidate id="login-form">
 
-          <div class="ds-field">
+          <div class="ds-field" id="field-email">
             <div class="ds-field__label-row">
               <label class="ds-field__label" for="login-email">E-mail</label>
             </div>
@@ -77,39 +64,35 @@
                 autocomplete="email"
                 required
                 aria-required="true"
+                aria-describedby="email-error"
               >
             </div>
+            <p class="ds-field__error" id="email-error" role="alert" aria-live="polite">Informe um e-mail válido</p>
           </div>
 
-          <div class="ds-field">
+          <div class="ds-field" id="field-password">
             <div class="ds-field__label-row">
               <label class="ds-field__label" for="login-password">Senha</label>
+              <a href="#" class="ds-link ds-text-body-sm">Esqueci minha senha</a>
             </div>
             <div class="ds-input">
               <input
                 class="ds-input__field"
                 id="login-password"
                 type="password"
-                placeholder="••••••••"
+                placeholder="Mínimo 8 caracteres"
                 autocomplete="current-password"
                 required
                 aria-required="true"
+                aria-describedby="password-error"
               >
             </div>
-            <div class="ds-field__helper">
-              <a href="#" class="ds-link">Esqueci minha senha</a>
-            </div>
+            <p class="ds-field__error" id="password-error" role="alert" aria-live="polite">A senha deve ter pelo menos 8 caracteres</p>
           </div>
 
-          <div class="ds-flex ds-flex-col ds-gap-md">
-            <button class="ds-btn ds-btn--brand ds-w-full" type="submit">
-              Entrar
-            </button>
-            <div class="ds-divider"></div>
-            <button class="ds-btn ds-btn--outline ds-w-full" type="button">
-              Entrar com Google
-            </button>
-          </div>
+          <button class="ds-btn ds-btn--brand ds-w-full" type="submit">
+            Entrar
+          </button>
 
         </form>
       </div>
@@ -119,12 +102,56 @@
     <div class="tpl-login-footer">
       <p class="ds-text-body-sm" style="color:var(--ds-content-subtle)">
         Não tem uma conta?
-        <a href="#" class="ds-link">Cadastre-se</a>
+        <a href="signup.html" class="ds-link">Cadastre-se grátis</a>
       </p>
     </div>
 
   </div>
 </main>
+
+<script>
+  (function () {
+    var form = document.getElementById('login-form');
+    var emailInput = document.getElementById('login-email');
+    var passwordInput = document.getElementById('login-password');
+
+    function showError(fieldId, inputEl, show) {
+      var field = document.getElementById(fieldId);
+      if (show) {
+        field.classList.add('ds-field--error');
+        inputEl.closest('.ds-input').classList.add('ds-input--error');
+        inputEl.setAttribute('aria-invalid', 'true');
+      } else {
+        field.classList.remove('ds-field--error');
+        inputEl.closest('.ds-input').classList.remove('ds-input--error');
+        inputEl.setAttribute('aria-invalid', 'false');
+      }
+    }
+
+    function validateEmail() {
+      var ok = emailInput.value.trim() !== '' && /\S+@\S+\.\S+/.test(emailInput.value);
+      showError('field-email', emailInput, !ok);
+      return ok;
+    }
+
+    function validatePassword() {
+      var ok = passwordInput.value.length >= 8;
+      showError('field-password', passwordInput, !ok);
+      return ok;
+    }
+
+    emailInput.addEventListener('blur', validateEmail);
+    passwordInput.addEventListener('blur', validatePassword);
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var ok = validateEmail() & validatePassword();
+      if (ok) {
+        /* submit logic goes here */
+      }
+    });
+  })();
+</script>
 
 </body>
 </html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -28,8 +28,8 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
+      min-height: 100vh;
       padding: var(--ds-space-section-md);
-      gap: var(--ds-space-2xl);
     }
     .tpl-signup-brand-content {
       display: flex;
@@ -64,7 +64,7 @@
     }
     .tpl-signup-form-wrapper {
       width: 100%;
-      max-width: var(--ds-size-layout-xs);
+      max-width: var(--ds-size-layout-sm);
       display: flex;
       flex-direction: column;
       gap: var(--ds-space-2xl);
@@ -110,7 +110,7 @@
         <h2 class="ds-text-heading-xl" style="color:var(--ds-primary-content-default)">
           O design system que escala com seu time
         </h2>
-        <p class="ds-text-body-md" style="color:var(--ds-primary-content-default);opacity:0.8;margin-top:var(--ds-space-md)">
+        <p class="ds-text-body-md" style="color:var(--ds-primary-content-default);margin-top:var(--ds-space-md)">
           300+ tokens, 19 componentes, suporte light/dark. Tudo pronto para consumir.
         </p>
       </div>
@@ -126,7 +126,7 @@
           </div>
           <div>
             <p class="ds-text-label-md" style="color:var(--ds-primary-content-default)">Ana Souza</p>
-            <p class="ds-text-body-xs" style="color:var(--ds-primary-content-default);opacity:0.7">Lead Designer, Acme Corp</p>
+            <p class="ds-text-body-xs" style="color:var(--ds-primary-content-default)">Lead Designer, Acme Corp</p>
           </div>
         </footer>
       </blockquote>


### PR DESCRIPTION
## O que foi corrigido

**`templates/login.html`**
- Remove botão "Entrar com Google" (não fazia parte do escopo)
- Remove bloco de branding "DS / Design System" sem hierarquia visual
- Fundo `--ds-surface-default` (branco) em vez de subtle cinza
- Card elevado (`ds-card--elevated`) em vez de outlined
- Validação inline com `ds-field--error` + `ds-input--error` no blur e no submit

**`templates/signup.html`**
- Form wrapper: `--ds-size-layout-xs` (320px) → `--ds-size-layout-sm` (480px) — causa raiz do campo Senha espremido
- Brand panel: `min-height: 100vh` para `justify-content: center` funcionar na coluna flex
- Remove `opacity: 0.8` do texto de descrição e do cargo no depoimento

**`docs/templates.html`**
- Cards de template agora em coluna (badge → nome → descrição) com `flex-direction: column`

**`docs/template-*.html` (4 páginas)**
- Linha divisória do heading "Visualização" agora cobre largura total (border-bottom no wrapper flex com `justify-content: space-between`, não no `h2`)

## Checklist
- [x] CSS reference test passa (0 refs órfãos)
- [x] Sem tokens inexistentes
- [x] Branch não toca em `main` diretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)