### PR TITLE
fix(button): corrige afastamento do focus ring

### DIFF
--- a/css/components/button.css
+++ b/css/components/button.css
@@ -4,7 +4,6 @@
    ============================================================ */
 
 .ds-button {
-  position: relative;
   --_ds-button-focus-ring-color: var(--ds-button-focus-ring-color-default);
   display: inline-flex;
   align-items: center;
@@ -32,16 +31,8 @@
 }
 
 .ds-button:focus-visible {
-  outline: none;
-}
-
-.ds-button:focus-visible::after {
-  content: "";
-  position: absolute;
-  inset: calc(-1 * (var(--ds-button-focus-ring-offset-default) + var(--ds-button-focus-ring-stroke-width-default)));
-  border: var(--ds-button-focus-ring-stroke-width-default) solid var(--_ds-button-focus-ring-color);
-  border-radius: var(--ds-button-focus-ring-radius-default);
-  pointer-events: none;
+  outline: var(--ds-button-focus-ring-stroke-width-default) solid var(--_ds-button-focus-ring-color);
+  outline-offset: var(--ds-button-focus-ring-offset-default);
 }
 
 .ds-button[disabled],

--- a/docs/button.html
+++ b/docs/button.html
@@ -8,18 +8,10 @@
   <link rel="stylesheet" href="layout.css">
   <style>
     .ds-button--docs-focused {
-      position: relative;
       background-color: var(--ds-button-bg-brand-focused);
       color: var(--ds-button-content-color-brand-focused);
-    }
-
-    .ds-button--docs-focused::after {
-      content: "";
-      position: absolute;
-      inset: calc(-1 * (var(--ds-button-focus-ring-offset-default) + var(--ds-button-focus-ring-stroke-width-default)));
-      border: var(--ds-button-focus-ring-stroke-width-default) solid var(--ds-button-focus-ring-color-default);
-      border-radius: var(--ds-button-focus-ring-radius-default);
-      pointer-events: none;
+      outline: var(--ds-button-focus-ring-stroke-width-default) solid var(--ds-button-focus-ring-color-default);
+      outline-offset: var(--ds-button-focus-ring-offset-default);
     }
   </style>
   <script>


### PR DESCRIPTION
## Resumo
- troca o focus ring do Button de pseudo-elemento para outline + outline-offset
- mantém os tokens Component de cor por variante
- alinha o exemplo focused da documentação ao mesmo padrão usado em Input e Select

## Validação
- npm run test:visual -- --filter button