### PR TITLE
fix(toggle): corrige posição do thumb checked

### DIFF
--- a/css/components/toggle.css
+++ b/css/components/toggle.css
@@ -82,8 +82,7 @@
 
 .ds-toggle:checked::after {
   background-color: var(--ds-toggle-thumb-fill-on-default);
-  /* Cálculo dinâmico e simétrico com largura corrigida */
-  transform: translateX(calc(var(--toggle-width) - var(--toggle-thumb-size) - (var(--thumb-gap) * 2) - (var(--ds-toggle-track-border-width-default) * 2)));
+  transform: translateX(calc(var(--toggle-width) - var(--toggle-thumb-size) - (var(--thumb-gap) * 2)));
 }
 
 /* Focus State */

--- a/docs/toggle.html
+++ b/docs/toggle.html
@@ -354,8 +354,8 @@
       <tbody>
         <tr><td><code>ds-toggle</code></td><td><span data-lang="pt">Switch estilizado (checkbox nativo)</span><span data-lang="en">Custom styled switch (native checkbox)</span></td></tr>
         <tr><td><code>ds-toggle-label</code></td><td><span data-lang="pt">Wrapper do controle (envolve track + conteúdo)</span><span data-lang="en">Control wrapper (wraps track + content)</span></td></tr>
-        <tr><td><code>ds-toggle--sm</code></td><td><span data-lang="pt">Tamanho pequeno (32x18px)</span><span data-lang="en">Small size (32x18px)</span></td></tr>
-        <tr><td><code>ds-toggle--lg</code></td><td><span data-lang="pt">Tamanho grande (48x26px)</span><span data-lang="en">Large size (48x26px)</span></td></tr>
+        <tr><td><code>ds-toggle--sm</code></td><td><span data-lang="pt">Tamanho pequeno (28x16px)</span><span data-lang="en">Small size (28x16px)</span></td></tr>
+        <tr><td><code>ds-toggle--lg</code></td><td><span data-lang="pt">Tamanho grande (56x32px)</span><span data-lang="en">Large size (56x32px)</span></td></tr>
         <tr><td><code>ds-toggle__content</code></td><td><span data-lang="pt">Frame vertical com label, description e helper text</span><span data-lang="en">Vertical frame stacking label, description, and helper text</span></td></tr>
         <tr><td><code>ds-toggle__label</code></td><td><span data-lang="pt">Texto do label (label/md)</span><span data-lang="en">Label text (label/md)</span></td></tr>
         <tr><td><code>ds-toggle__description</code></td><td><span data-lang="pt">Texto descritivo multiline (body/sm)</span><span data-lang="en">Multiline description text (body/sm)</span></td></tr>


### PR DESCRIPTION
## Resumo
- Corrige o cálculo do thumb no Toggle checked para não subtrair a borda duas vezes.
- Atualiza a documentação de classes com os tamanhos reais atuais: sm 28x16 e lg 56x32.

## Validação
- npm run verify:tokens
- npm test
- captura local de docs/toggle.html confirmando deslocamentos checked: sm 12px, md 20px, lg 24px