### PR TITLE
fix(controls): alinha strokes de estados preenchidos

### DIFF
--- a/css/components/checkbox.css
+++ b/css/components/checkbox.css
@@ -89,7 +89,7 @@
 /* Checked */
 .ds-checkbox:checked {
   background-color: var(--ds-checkbox-box-fill-checked-default);
-  border-color: var(--ds-checkbox-box-border-color-checked-default);
+  border-width: 0;
 }
 
 .ds-checkbox:checked::after {
@@ -99,7 +99,7 @@
 /* Indeterminate */
 .ds-checkbox:indeterminate {
   background-color: var(--ds-checkbox-box-fill-indeterminate-default);
-  border-color: var(--ds-checkbox-box-border-color-indeterminate-default);
+  border-width: 0;
 }
 
 .ds-checkbox:indeterminate::after {
@@ -128,7 +128,7 @@
 
 .ds-checkbox:checked:disabled {
   background-color: var(--ds-checkbox-box-fill-checked-disabled);
-  border-color: var(--ds-checkbox-box-border-color-checked-disabled);
+  border-width: 0;
 }
 
 .ds-checkbox:checked:disabled::after {
@@ -137,7 +137,7 @@
 
 .ds-checkbox:indeterminate:disabled {
   background-color: var(--ds-checkbox-box-fill-indeterminate-disabled);
-  border-color: var(--ds-checkbox-box-border-color-indeterminate-disabled);
+  border-width: 0;
 }
 
 .ds-checkbox:indeterminate:disabled::after {

--- a/css/components/radio.css
+++ b/css/components/radio.css
@@ -129,6 +129,7 @@
 .ds-radio:checked:disabled {
   background-color: var(--ds-radio-control-fill-selected-disabled);
   border-color: var(--ds-radio-control-border-color-selected-disabled);
+  border-width: 0;
 }
 
 .ds-radio:checked:disabled::after {

--- a/css/components/toggle.css
+++ b/css/components/toggle.css
@@ -77,7 +77,7 @@
 /* Checked (On) State */
 .ds-toggle:checked {
   background-color: var(--ds-toggle-track-fill-on-default);
-  border-color: var(--ds-toggle-track-fill-on-default);
+  border-width: 0;
 }
 
 .ds-toggle:checked::after {
@@ -104,7 +104,7 @@
 
 .ds-toggle:checked:disabled {
   background-color: var(--ds-toggle-track-fill-on-disabled);
-  border-color: var(--ds-toggle-track-fill-on-disabled);
+  border-width: 0;
 }
 
 .ds-toggle:checked:disabled::after {


### PR DESCRIPTION
## Resumo
- Alinha Checkbox, Radio e Toggle ao Figma live para estados preenchidos sem stroke.
- Checkbox checked/indeterminate passam a remover border, como o Control no Figma.
- Radio selected disabled remove border, como o variant Disabled + Selected no Figma.
- Toggle on/on disabled remove border, como a Track On no Figma.

## Validação
- Figma live audit: strokeCount esperado por estado em Checkbox/Radio/Toggle.
- Render local audit via Playwright para Checkbox, Radio e Toggle.
- npm run verify:tokens
- npm test