### PR TITLE
fix(controls): ajusta paridade visual de checkbox e toggle

### DIFF
--- a/css/components/checkbox.css
+++ b/css/components/checkbox.css
@@ -71,13 +71,14 @@
 .ds-checkbox::after {
   content: '';
   position: absolute;
-  top: 2px;
-  left: 6px;
-  width: 5px;
-  height: 10px;
-  border: solid var(--ds-checkbox-mark-fill-checked-default);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg) scale(0);
+  top: 50%;
+  left: 50%;
+  width: calc(var(--checkbox-box-size) * 0.7);
+  height: calc(var(--checkbox-box-size) * 0.7);
+  background-color: var(--ds-checkbox-mark-fill-checked-default);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.2 11.2 2.8 7.8 1.4 9.2l4.8 4.8L14.6 5.6 13.2 4.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.2 11.2 2.8 7.8 1.4 9.2l4.8 4.8L14.6 5.6 13.2 4.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  transform: translate(-50%, -50%) scale(0);
   transition: transform var(--ds-motion-duration-fast) var(--ds-motion-ease-default);
 }
 
@@ -93,7 +94,7 @@
 }
 
 .ds-checkbox:checked::after {
-  transform: rotate(45deg) scale(1);
+  transform: translate(-50%, -50%) scale(1);
 }
 
 /* Indeterminate */
@@ -107,8 +108,9 @@
   left: 50%;
   width: 10px;
   height: 2px;
-  border: none;
   background-color: var(--ds-checkbox-mark-fill-indeterminate-default);
+  -webkit-mask: none;
+  mask: none;
   transform: translate(-50%, -50%) scale(1);
   border-radius: 1px;
 }
@@ -132,7 +134,7 @@
 }
 
 .ds-checkbox:checked:disabled::after {
-  border-color: var(--ds-checkbox-mark-fill-checked-disabled);
+  background-color: var(--ds-checkbox-mark-fill-checked-disabled);
 }
 
 .ds-checkbox:indeterminate:disabled {
@@ -189,14 +191,6 @@
   height: var(--ds-checkbox-box-size-sm);
 }
 
-.ds-checkbox--sm::after {
-  top: 1px;
-  left: 4.5px;
-  width: 4px;
-  height: 8px;
-  border-width: 0 1.5px 1.5px 0;
-}
-
 .ds-checkbox--sm:indeterminate::after {
   width: 8px;
   height: 1.5px;
@@ -211,14 +205,6 @@
 .ds-checkbox--lg {
   width: var(--ds-checkbox-box-size-lg);
   height: var(--ds-checkbox-box-size-lg);
-}
-
-.ds-checkbox--lg::after {
-  top: 3px;
-  left: 7.5px;
-  width: 6px;
-  height: 12px;
-  border-width: 0 2.5px 2.5px 0;
 }
 
 .ds-checkbox--lg:indeterminate::after {

--- a/css/components/textarea.css
+++ b/css/components/textarea.css
@@ -86,11 +86,13 @@
 }
 
 /* Error */
-.ds-textarea--error {
+.ds-textarea--error,
+.ds-field--error .ds-textarea {
   border-color: var(--ds-textarea-border-color-error);
 }
 
-.ds-textarea--error:focus-within {
+.ds-textarea--error:focus-within,
+.ds-field--error .ds-textarea:focus-within {
   border-color: var(--ds-textarea-border-color-error);
   outline-color: var(--ds-textarea-focus-ring-color-error);
 }

--- a/css/components/toggle.css
+++ b/css/components/toggle.css
@@ -49,6 +49,7 @@
   --toggle-height: var(--ds-toggle-track-height-md);
   --toggle-width: var(--ds-toggle-track-width-md);
   --thumb-gap: var(--ds-toggle-thumb-inset-default);
+  --track-border-width: var(--ds-toggle-track-border-width-default);
   
   width: var(--toggle-width);
   height: var(--toggle-height);
@@ -58,8 +59,8 @@
 .ds-toggle::after {
   content: '';
   position: absolute;
-  top: var(--thumb-gap);
-  left: var(--thumb-gap);
+  top: calc(var(--thumb-gap) - var(--track-border-width));
+  left: calc(var(--thumb-gap) - var(--track-border-width));
   width: var(--toggle-thumb-size);
   height: var(--toggle-thumb-size);
   border-radius: var(--ds-toggle-thumb-radius-default);
@@ -78,6 +79,7 @@
 .ds-toggle:checked {
   background-color: var(--ds-toggle-track-fill-on-default);
   border-width: 0;
+  --track-border-width: 0px;
 }
 
 .ds-toggle:checked::after {

--- a/docs/textarea.html
+++ b/docs/textarea.html
@@ -225,7 +225,7 @@
         <div class="ds-preview__canvas ds-preview__canvas--column" style="max-width:400px">
           <div class="ds-field ds-field--error">
             <label class="ds-field__label" for="demo-msg">Message</label>
-            <div class="ds-textarea">
+            <div class="ds-textarea ds-textarea--error">
               <textarea class="ds-textarea__field" id="demo-msg" aria-invalid="true" aria-describedby="msg-error">Too short</textarea>
             </div>
             <span class="ds-field__error" id="msg-error">Message must be at least 20 characters.</span>
@@ -237,7 +237,7 @@
           <button class="ds-preview__copy" aria-label="Copy code">Copy</button>
           <pre tabindex="0"><code>&lt;div class="ds-field ds-field--error"&gt;
   &lt;label class="ds-field__label" for="msg"&gt;Message&lt;/label&gt;
-  &lt;div class="ds-textarea"&gt;
+  &lt;div class="ds-textarea ds-textarea--error"&gt;
     &lt;textarea class="ds-textarea__field" id="msg"
       aria-invalid="true" aria-describedby="msg-error"&gt;&lt;/textarea&gt;
   &lt;/div&gt;


### PR DESCRIPTION
## O que muda
- Corrige a geometria do Toggle off: o thumb compensa a borda do track para manter inset visual consistente.
- Troca o checkmark do Checkbox de stroke manual rotacionado para máscara SVG centralizada e proporcional ao box.
- Faz Textarea em ds-field--error aplicar borda/focus ring de erro e atualiza o exemplo da doc.

## Validação
- npm run verify:tokens
- npm test
- Medição local via Playwright de Toggle, Checkbox e Textarea